### PR TITLE
Dev Container Support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+{
+    "name": "hopskipnfall-emulinker-k",
+    "dockerComposeFile": "../docker-compose.yaml",
+    "service": "develop",
+    "workspaceFolder": "/app",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "fwcd.kotlin",
+                "ms-azuretools.vscode-docker",
+                "vscjava.vscode-gradle",
+                "EditorConfig.EditorConfig"
+            ],
+            "settings": {
+                "kotlin.debugAdapter.enabled": true,
+                "kotlin.debugAdapter.path": "/home/gradle/bin/kotlin-debug-adapter",
+                "kotlin.languageServer.enabled": true,
+                "kotlin.languageServer.path": "/home/gradle/bin/kotlin-language-server"
+            }
+        }
+    }
+}

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{kt,kts}]
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ metrics/
 .DS_Store
 
 .gradle
+
+.settings/org.eclipse.buildship.core.prefs

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "kotlin",
+            "request": "launch",
+            "name": "Build & Debug",
+            "projectRoot": "${workspaceFolder}/emulinker",
+            "mainClass": "org.emulinker.kaillera.pico.ServerMainKt",
+            "vmArguments": "-DLOG_DIRECTORY=/tmp",
+            "preLaunchTask": "gradle: emulinker:build",
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,10 @@
 {
-  "java.configuration.updateBuildConfiguration": "automatic",
-"java.format.settings.url": "https://raw.githubusercontent.com/google/styleguide/gh-pages/eclipse-java-google-style.xml",
-"java.format.settings.profile": "GoogleStyle",
-"java.autobuild.enabled": true,
-"maven.view": "flat"
+    "java.configuration.updateBuildConfiguration": "automatic",
+    "java.format.settings.url": "https://raw.githubusercontent.com/google/styleguide/gh-pages/eclipse-java-google-style.xml",
+    "java.format.settings.profile": "GoogleStyle",
+    "java.autobuild.enabled": true,
+    "maven.view": "flat",
+    "files.exclude": {
+        "**/.settings": false,
+    }
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,47 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "type": "gradle",
+            "id": "emulinker:buildemulinker",
+            "script": "emulinker:build",
+            "description": "Assembles and tests this project.",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "project": "emulinker",
+            "buildFile": "${workspaceFolder}/emulinker/build.gradle.kts",
+            "rootProject": "emulinker-k",
+            "projectFolder": "${workspaceFolder}",
+            "workspaceFolder": "${workspaceFolder}",
+            "args": "",
+            "javaDebug": false,
+            "problemMatcher": [
+                "$gradle"
+            ],
+            "label": "gradle: emulinker:build"
+        },
+        {
+            "type": "gradle",
+            "id": "emulinker:testemulinker",
+            "script": "emulinker:test",
+            "description": "Runs the test suite.",
+            "group": {
+                "kind": "test",
+                "isDefault": true
+            },
+            "project": "emulinker",
+            "buildFile": "${workspaceFolder}/emulinker/build.gradle.kts",
+            "rootProject": "emulinker-k",
+            "projectFolder": "${workspaceFolder}",
+            "workspaceFolder": "${workspaceFolder}",
+            "args": "",
+            "javaDebug": false,
+            "problemMatcher": [
+                "$gradle"
+            ],
+            "label": "gradle: emulinker:test"
+        },
+    ]
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+ARG GRADLE_VERSION=8.1.1
+ARG JDK_VERSION=17
+
+FROM gradle:${GRADLE_VERSION}-jdk${JDK_VERSION}-jammy as develop
+
+LABEL org.opencontainers.image.authors="hopskipnfall"
+LABEL org.opencontainers.image.source="https://github.com/hopskipnfall/EmuLinker-K"
+
+ARG JDK_VERSION
+ARG KOTLIN_DEBUG_ADAPTER=https://github.com/fwcd/kotlin-debug-adapter.git
+ARG KOTLIN_LANGUAGE_SERVER=https://github.com/fwcd/kotlin-language-server.git
+
+USER gradle
+
+# build kotlin-language-server and kotlin-debug-adapter directly
+# kotlin-debug-adapter from the vscode extension does not seem
+# to work correctly with external dependencies
+WORKDIR /home/gradle
+
+# hadolint ignore=DL3003
+RUN git clone ${KOTLIN_DEBUG_ADAPTER} \
+    && mkdir -p bin \
+    && (cd kotlin-debug-adapter && ./gradlew :adapter:installDist -PjavaVersion=${JDK_VERSION}) \
+    && ln -sf ~/kotlin-debug-adapter/adapter/build/install/adapter/bin/kotlin-debug-adapter bin/
+
+# hadolint ignore=DL3003
+RUN git clone ${KOTLIN_LANGUAGE_SERVER} \
+    && mkdir -p bin \
+    && (cd kotlin-language-server && ./gradlew :server:installDist -PjavaVersion=${JDK_VERSION}) \
+    && ln -sf ~/kotlin-language-server/server/build/install/server/bin/kotlin-language-server bin/
+
+WORKDIR /app
+
+# miscellaneous fixes
+RUN git config --global --add safe.directory /app
+
+ENTRYPOINT []

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,24 +1,39 @@
----
-version: "3.7"
 services:
+  develop:
+    container_name: hopskipnfall-emulinker-k_develop
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: develop
+      args:
+        GRADLE_VERSION: 8.1.1
+        JDK_VERSION: 17
+        KOTLIN_DEBUG_ADAPTER: https://github.com/fwcd/kotlin-debug-adapter.git
+        KOTLIN_LANGUAGE_SERVER: https://github.com/fwcd/kotlin-language-server.git
+    ports:
+      - "27888-27999:27888-27999/udp"
+    tty: true
+    volumes:
+      - ./:/app
+
   kaillera_server:
     image: "maven:3.8-jdk-11"
     command: "sh -c \"mvn -f /home/app/emulinker/pom.xml compile exec:java\""
     working_dir: "/emulinker"
     ports:
-    - "27888-27999:27888-27999/udp"
+      - "27888-27999:27888-27999/udp"
     volumes:
-    - "./:/home/app/"
+      - "./:/home/app/"
   graphite:
     profiles:
-    - "debug"
+      - "debug"
     image: "graphiteapp/graphite-statsd"
     ports:
-    - "80:80"
-    - "2003-2004:2003-2004"
-    - "2023-2024:2023-2024"
-    - "8125:8125/udp"
-    - "8126:8126"
+      - "80:80"
+      - "2003-2004:2003-2004"
+      - "2023-2024:2023-2024"
+      - "8125:8125/udp"
+      - "8126:8126"
     deploy:
       restart_policy:
         condition: "any"

--- a/emulinker/conf/log4j2.properties
+++ b/emulinker/conf/log4j2.properties
@@ -6,10 +6,12 @@ appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = [%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %c{1} - %msg%n
 
 # Rotate log file
+property.logDir = ${sys:LOG_DIRECTORY:-.}
+
 appender.rolling.type = RollingFile
 appender.rolling.name = LogToRollingFile
-appender.rolling.fileName = emulinker.log
-appender.rolling.filePattern = logs/$${date:yyyy-MM}/emulinker-%d{MM-dd-yyyy}-%i.log.gz
+appender.rolling.fileName = ${logDir}/emulinker.log
+appender.rolling.filePattern = ${logDir}/logs/$${date:yyyy-MM}/emulinker-%d{MM-dd-yyyy}-%i.log.gz
 appender.rolling.layout.type = PatternLayout
 appender.rolling.layout.pattern = %d %p %C{1.} [%t] %m%n
 appender.rolling.policies.type = Policies


### PR DESCRIPTION
Adds initial development container support within VS Code. This uses a [gradle](https://hub.docker.com/_/gradle/) docker image as its base and builds the [kotlin language server](https://github.com/fwcd/kotlin-language-server) to improve Kotlin support within VS Code, in addition to getting debugging support working.

The language server seems to be in a bit of development limbo right now (see their GitHub for more info), but it works well enough and it's the only option available. This still not as integrated as IntelliJ IDEA, but it's not trying to be. This should provide a more lightweight option for others to contribute code with.

Included extensions:
- [Kotlin](https://marketplace.visualstudio.com/items?itemName=fwcd.kotlin)
- [Docker](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-docker)
- [Gradle for Java](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-gradle)
- [EditorConfig for VS Code](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig)

Let me know if you want to tweak the dev container at all, as I made some assumptions on the environment. The Docker and EditorConfig extensions aren't strictly necessary, but I felt they were probably useful enough to include.