### PR TITLE
Performance improvements for user actions, fix scheduled tasks

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -7,7 +7,6 @@ on:
   pull_request:
     branches:
       - "master"
-      - "fewer-ports"
 
 permissions:
   contents: read

--- a/emulinker/build.gradle.kts
+++ b/emulinker/build.gradle.kts
@@ -81,6 +81,7 @@ tasks.processResources {
             val name = project.description
             val version = project.version
             val url = properties["url"]
+            val prerelease = properties["prerelease"]
           },
         "useBytereadpacketInsteadOfBytebuffer" to false,
       )

--- a/emulinker/conf/language.properties
+++ b/emulinker/conf/language.properties
@@ -16,6 +16,7 @@ KailleraServerImpl.LoginMessage.1=Welcome to a new EmuLinker-K Server!
 KailleraServerImpl.LoginMessage.2=Edit emulinker.cfg to setup your server configuration
 KailleraServerImpl.LoginMessage.3=Edit language.properties to setup your login announcements
 
+KailleraServerImpl.JoinGameMessage.1=Message that appears when a user joins/starts a game!
 
 # Other Announcements
 KailleraServerImpl.UserCreatedGameAnnouncement={0} created game: {1}

--- a/emulinker/src/main/java-templates/org/emulinker/kaillera/pico/CompiledFlags.kt
+++ b/emulinker/src/main/java-templates/org/emulinker/kaillera/pico/CompiledFlags.kt
@@ -15,4 +15,7 @@ object CompiledFlags {
   val BUILD_DATE: Instant = Instant.ofEpochSecond(${buildTimestampSeconds})
 
   const val USE_BYTEREADPACKET_INSTEAD_OF_BYTEBUFFER: Boolean = ${useBytereadpacketInsteadOfBytebuffer}
+
+  /** Indicates a build still in development (and lacking a unique version number). */
+  const val PRERELEASE_BUILD: Boolean = ${project.prerelease}
 }

--- a/emulinker/src/main/java/org/emulinker/kaillera/lookingforgame/TwitterBroadcaster.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/lookingforgame/TwitterBroadcaster.kt
@@ -63,9 +63,13 @@ internal constructor(
         val message =
           "User: ${user.name}\nGame: ${lookingForGameEvent.gameTitle}\nServer: ${flags.serverName} (${flags.serverAddress})"
         val tweet = twitter.postTweet(message)
-        user.game!!.announce(getUrl(tweet, twitter.userIdFromAccessToken), user)
-        logger.atFine().log("Posted tweet: %s", getUrl(tweet, twitter.userIdFromAccessToken))
-        postedTweets[lookingForGameEvent] = tweet.id
+        if (tweet.id == null) {
+          logger.atWarning().log("Unable to post tweet")
+        } else {
+          user.game!!.announce(getUrl(tweet, twitter.userIdFromAccessToken), user)
+          logger.atFine().log("Posted tweet: %s", getUrl(tweet, twitter.userIdFromAccessToken))
+          postedTweets[lookingForGameEvent] = tweet.id
+        }
       }
     pendingReports[lookingForGameEvent] = timerTask
     return true

--- a/emulinker/src/main/java/org/emulinker/kaillera/master/client/EmuLinkerMasterUpdateTask.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/master/client/EmuLinkerMasterUpdateTask.kt
@@ -12,7 +12,6 @@ import org.apache.commons.configuration.Configuration
 import org.emulinker.kaillera.master.PublicServerInformation
 import org.emulinker.kaillera.model.GameStatus
 import org.emulinker.kaillera.model.KailleraServer
-import org.emulinker.kaillera.release.ReleaseInfo
 
 class EmuLinkerMasterUpdateTask
 @Inject
@@ -20,7 +19,6 @@ constructor(
   private val publicInfo: PublicServerInformation,
   private val config: Configuration,
   private val kailleraServer: KailleraServer,
-  private val releaseInfo: ReleaseInfo,
 ) : MasterListUpdateTask {
 
   override fun reportStatus() {
@@ -35,7 +33,9 @@ constructor(
       this.append("maxUsers", kailleraServer.maxUsers.toString())
       this.append("numGames", kailleraServer.games.size.toString())
       this.append("maxGames", kailleraServer.maxGames.toString())
-      this.append("version", releaseInfo.versionWithElkPrefix)
+      // I want to use `releaseInfo.versionWithElkPrefix` here, but it's too long for the db schema
+      // field, so we just write elk (lowercase in protest :P ).
+      this.append("version", "elk")
     }
 
     val connection: HttpURLConnection = URL(url.buildString()).openConnection() as HttpURLConnection
@@ -77,5 +77,7 @@ constructor(
     private val logger = FluentLogger.forEnclosingClass()
 
     private const val TOUCH_LIST_URL = "http://kaillerareborn.2manygames.fr/touch_list.php"
+
+    private const val FETCH_LIST_URL = "http://kaillerareborn.2manygames.fr/game_list.php"
   }
 }

--- a/emulinker/src/main/java/org/emulinker/kaillera/master/client/KailleraMasterUpdateTask.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/master/client/KailleraMasterUpdateTask.kt
@@ -42,8 +42,8 @@ constructor(
       this.append("port", config.getInt("controllers.connect.port").toString())
       this.append("nbusers", kailleraServer.users.size.toString())
       this.append("maxconn", kailleraServer.maxUsers.toString())
-      // I want to use `releaseInfo.versionWithElkPrefix` here, but for some reason this RPC
-      // fails to write to the db. So we just write elk (lowercase in protest :P ).
+      // I want to use `releaseInfo.versionWithElkPrefix` here, but it's too long for the db schema
+      // field, so we just write elk (lowercase in protest :P ).
       this.append("version", "elk")
       this.append("nbgames", kailleraServer.games.size.toString())
       this.append("location", publicInfo.location)
@@ -94,5 +94,7 @@ constructor(
     private val logger = FluentLogger.forEnclosingClass()
 
     private const val TOUCH_LIST_URL = "http://www.kaillera.com/touch_server.php"
+
+    private const val FETCH_LIST_URL = "http://www.kaillera.com/raw_server_list2.php"
   }
 }

--- a/emulinker/src/main/java/org/emulinker/kaillera/master/client/ServerCheckinTask.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/master/client/ServerCheckinTask.kt
@@ -16,6 +16,7 @@ import org.apache.commons.configuration.Configuration
 import org.emulinker.kaillera.master.PublicServerInformation
 import org.emulinker.kaillera.pico.AppModule
 import org.emulinker.kaillera.pico.CompiledFlags
+import org.emulinker.kaillera.release.ReleaseInfo
 
 @Serializable
 data class ServerInfo(
@@ -43,6 +44,7 @@ class ServerCheckinTask
 constructor(
   private val publicServerInfo: PublicServerInformation,
   private val config: Configuration,
+  private val releaseInfo: ReleaseInfo,
 ) : MasterListUpdateTask {
 
   override fun reportStatus() {
@@ -82,7 +84,7 @@ constructor(
           website = publicServerInfo.website,
           location = publicServerInfo.location,
           charset = AppModule.charsetDoNotUse.name,
-          version = CompiledFlags.PROJECT_VERSION,
+          version = releaseInfo.versionWithElkPrefix,
           isDevBuild = CompiledFlags.DEBUG_BUILD
         )
       )

--- a/emulinker/src/main/java/org/emulinker/kaillera/pico/AppModule.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/pico/AppModule.kt
@@ -25,6 +25,7 @@ import org.emulinker.kaillera.master.MasterListStatsCollector
 import org.emulinker.kaillera.master.StatsCollector
 import org.emulinker.kaillera.model.impl.AutoFireDetectorFactory
 import org.emulinker.kaillera.model.impl.AutoFireDetectorFactoryImpl
+import org.emulinker.util.EmuLang
 import org.emulinker.util.EmuLinkerPropertiesConfig
 
 @Module
@@ -116,6 +117,17 @@ abstract class AppModule {
     @Singleton
     fun provideMetricRegistry(): MetricRegistry {
       return MetricRegistry()
+    }
+
+    @Provides
+    @Singleton
+    @Named("joinGameMessages")
+    fun provideJoinGameMessages(): List<String> = buildList {
+      var i = 1
+      while (EmuLang.hasString("KailleraServerImpl.JoinGameMessage.$i")) {
+        add(EmuLang.getString("KailleraServerImpl.JoinGameMessage.$i"))
+        i++
+      }
     }
   }
 }

--- a/emulinker/src/main/java/org/emulinker/kaillera/release/ReleaseInfo.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/release/ReleaseInfo.kt
@@ -25,7 +25,7 @@ class ReleaseInfo @Inject constructor() {
 
   val websiteString: String = PROJECT_URL
 
-  val licenseInfo = "Usage of this sofware is subject to the terms found in the included license"
+  val licenseInfo = "Usage of this software is subject to the terms found in the included license"
 
   /**
    * Formats release information into a welcome message. This message is printed by the server at

--- a/emulinker/src/main/java/org/emulinker/kaillera/release/ReleaseInfo.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/release/ReleaseInfo.kt
@@ -2,6 +2,7 @@ package org.emulinker.kaillera.release
 
 import java.time.Instant
 import javax.inject.Inject
+import org.emulinker.kaillera.pico.CompiledFlags
 import org.emulinker.kaillera.pico.CompiledFlags.BUILD_DATE
 import org.emulinker.kaillera.pico.CompiledFlags.PROJECT_NAME
 import org.emulinker.kaillera.pico.CompiledFlags.PROJECT_URL
@@ -15,7 +16,8 @@ import org.emulinker.util.EmuUtil
 class ReleaseInfo @Inject constructor() {
   val productName: String = PROJECT_NAME
 
-  val version: String = PROJECT_VERSION
+  val version: String =
+    if (CompiledFlags.PRERELEASE_BUILD) "$PROJECT_VERSION (pre-release)" else PROJECT_VERSION
 
   val versionWithElkPrefix: String = "ELK$version"
 

--- a/emulinker/src/main/java/org/emulinker/util/EmuUtil.kt
+++ b/emulinker/src/main/java/org/emulinker/util/EmuUtil.kt
@@ -285,16 +285,13 @@ object EmuUtil {
     }
   }
 
-  fun toSimpleUtcDatetime(instant: Instant): String {
-    return DateTimeFormatter.RFC_1123_DATE_TIME.withZone(ZoneOffset.UTC).format(instant)
-  }
+  fun toSimpleUtcDatetime(instant: Instant): String =
+    DateTimeFormatter.RFC_1123_DATE_TIME.withZone(ZoneOffset.UTC).format(instant)
 
-  // TODO(nue): Get rid of this.
-  /** Calls [Thread.sleep] in a try/catch. */
-  @Deprecated(message = "You should probably use delay!")
+  // TODO(nue): Get rid of this after it's confirmed it can be safely removed.
+  /** NOOP placeholder for a function that _used to_ call [Thread.sleep]. */
+  @Deprecated(message = "Don't sleep!", level = DeprecationLevel.WARNING)
   fun threadSleep(d: Duration) {
-    try {
-      Thread.sleep(d.inWholeMilliseconds)
-    } catch (e: Exception) {}
+    // try { Thread.sleep(d.inWholeMilliseconds) } catch (e: Exception) {}
   }
 }

--- a/emulinker/src/main/java/org/emulinker/util/TaskScheduler.kt
+++ b/emulinker/src/main/java/org/emulinker/util/TaskScheduler.kt
@@ -19,9 +19,19 @@ import kotlin.time.Duration.Companion.seconds
 class TaskScheduler @Inject constructor() {
   private var timer = Timer(/* isDaemon= */ true)
 
-  fun schedule(delay: Duration = 0.seconds, action: TimerTask.() -> Unit): TimerTask =
+  fun schedule(delay: Duration = 0.seconds, action: () -> Unit): TimerTask =
     try {
-      timer.schedule(delay = delay.inWholeMilliseconds, action)
+      timer.schedule(delay = delay.inWholeMilliseconds) {
+        // Wrap the action in a try/catch to prevent exceptions from killing the timer.
+        try {
+          action()
+        } catch (e: Exception) {
+          logger
+            .atWarning()
+            .withCause(e)
+            .log("Caught an exception that would have killed the timer")
+        }
+      }
     } catch (e: Exception) {
       logger
         .atWarning()
@@ -30,20 +40,39 @@ class TaskScheduler @Inject constructor() {
 
       timer = Timer()
 
-      timer.schedule(delay = delay.inWholeMilliseconds, action)
+      timer.schedule(delay = delay.inWholeMilliseconds) {
+        // Wrap the action in a try/catch to prevent exceptions from killing the timer.
+        try {
+          action()
+        } catch (e: Exception) {
+          logger
+            .atWarning()
+            .withCause(e)
+            .log("Caught an exception that would have killed the timer")
+        }
+      }
     }
 
   fun scheduleRepeating(
     period: Duration,
     initialDelay: Duration = 0.seconds,
-    action: TimerTask.() -> Unit
+    action: () -> Unit
   ): TimerTask =
     try {
       timer.schedule(
         delay = initialDelay.inWholeMilliseconds,
         period = period.inWholeMilliseconds,
-        action
-      )
+      ) {
+        // Wrap the action in a try/catch to prevent exceptions from killing the timer.
+        try {
+          action()
+        } catch (e: Exception) {
+          logger
+            .atWarning()
+            .withCause(e)
+            .log("Caught an exception that would have killed the timer")
+        }
+      }
     } catch (e: Exception) {
       logger
         .atWarning()
@@ -54,9 +83,18 @@ class TaskScheduler @Inject constructor() {
 
       timer.schedule(
         delay = initialDelay.inWholeMilliseconds,
-        period = period.inWholeMilliseconds,
-        action
-      )
+        period = period.inWholeMilliseconds
+      ) {
+        // Wrap the action in a try/catch to prevent exceptions from killing the timer.
+        try {
+          action()
+        } catch (e: Exception) {
+          logger
+            .atWarning()
+            .withCause(e)
+            .log("Caught an exception that would have killed the timer")
+        }
+      }
     }
 
   private companion object {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 prodBuild=false
 url=https://github.com/hopskipnfall/EmuLinker-K
+prerelease=true


### PR DESCRIPTION
At HEAD I've confirmed there is noticable lag at the following places:

- New user connects
- User quits a game

There is likely lag when various commands are run as well.

After removing _all 90_ calls to `Thread.sleep()`, this appears to be fixed. It's possible this causes bugs like:

- Messages being sent out of order (for their message number)
- Messages sent in quick succession (e.g. /help command or a user joins the server) end up out of order