### PR TITLE
Ignore time spent waiting on other users when calculating lag

### DIFF
--- a/emulinker/build.gradle.kts
+++ b/emulinker/build.gradle.kts
@@ -49,6 +49,8 @@ dependencies {
   implementation("io.ktor:ktor-server-status-pages-jvm:$ktorVersion")
   implementation("io.ktor:ktor-server-default-headers-jvm:$ktorVersion")
 
+  implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.6.1")
+
   // This is only used by the fake testing client, hopefully we can remove this.
   testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.1")
 

--- a/emulinker/src/main/java/org/emulinker/config/RuntimeFlags.kt
+++ b/emulinker/src/main/java/org/emulinker/config/RuntimeFlags.kt
@@ -30,7 +30,7 @@ data class RuntimeFlags(
   val maxGameChatLength: Int,
   val maxGameNameLength: Int,
   val maxGames: Int,
-  val maxPing: Int,
+  val maxPing: Duration,
   val maxQuitMessageLength: Int,
   val maxUserNameLength: Int,
   val maxUsers: Int,
@@ -62,7 +62,7 @@ data class RuntimeFlags(
     require(maxUserNameLength <= 31) { "server.maxUserNameLength must be <= 31" }
     require(maxGameNameLength <= 127) { "server.maxGameNameLength must be <= 127" }
     require(maxClientNameLength <= 127) { "server.maxClientNameLength must be <= 127" }
-    require(maxPing in 1..1000) { "server.maxPing must be in 1..1000" }
+    require(maxPing in 1.milliseconds..1000.milliseconds) { "server.maxPing must be in 1..1000" }
     require(keepAliveTimeout.isPositive()) {
       "server.keepAliveTimeout must be > 0 (190 is recommended)"
     }
@@ -104,7 +104,7 @@ data class RuntimeFlags(
         maxGameChatLength = config.getInt("server.maxGameChatLength"),
         maxGameNameLength = config.getInt("server.maxGameNameLength"),
         maxGames = config.getInt("server.maxGames"),
-        maxPing = config.getInt("server.maxPing"),
+        maxPing = config.getInt("server.maxPing").milliseconds,
         maxQuitMessageLength = config.getInt("server.maxQuitMessageLength"),
         maxUserNameLength = config.getInt("server.maxUserNameLength"),
         maxUsers = config.getInt("server.maxUsers"),

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/V086ClientHandler.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/V086ClientHandler.kt
@@ -355,9 +355,12 @@ constructor(
     }
   }
 
+  // Caching here for speed.
+  private val maxPingMs: Long = flags.maxPing.inWholeMilliseconds
+
   fun resend(timeoutCounter: Int) {
     // if ((System.currentTimeMillis() - lastResend) > (user.getPing()*3))
-    if (System.currentTimeMillis() - lastResend > controller.server.maxPing) {
+    if (System.currentTimeMillis() - lastResend > maxPingMs) {
       // int numToSend = (3+timeoutCounter);
       var numToSend = 3 * timeoutCounter
       if (numToSend > V086Controller.MAX_BUNDLE_SIZE) numToSend = V086Controller.MAX_BUNDLE_SIZE

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameChatAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameChatAction.kt
@@ -484,6 +484,18 @@ internal constructor(
         } else {
           clientHandler.user.game!!.announce("No pending tweets.", clientHandler.user)
         }
+      } else if (message.message == "/lagstat") {
+        // Note: This was duplicated from GameOwnerCommandAction.
+        clientHandler.user.game!!.announce("Lagged frames per player:")
+        clientHandler.user.game!!
+          .players
+          .asSequence()
+          .filter { !it.inStealthMode }
+          .forEach {
+            clientHandler.user.game!!.announce(
+              "P${it.playerNumber}: ${it.smallLagSpikesCausedByUser} (tiny), ${it.bigLagSpikesCausedByUser} (big)"
+            )
+          }
       } else
         clientHandler.user.game!!.announce(
           "Unknown Command: " + message.message,

--- a/emulinker/src/main/java/org/emulinker/kaillera/master/client/EmuLinkerMasterUpdateTask.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/master/client/EmuLinkerMasterUpdateTask.kt
@@ -30,9 +30,9 @@ constructor(
       this.append("website", publicInfo.website)
       this.append("port", flags.serverPort.toString())
       this.append("numUsers", kailleraServer.users.size.toString())
-      this.append("maxUsers", kailleraServer.maxUsers.toString())
+      this.append("maxUsers", flags.maxUsers.toString())
       this.append("numGames", kailleraServer.games.size.toString())
-      this.append("maxGames", kailleraServer.maxGames.toString())
+      this.append("maxGames", flags.maxGames.toString())
       // I want to use `releaseInfo.versionWithElkPrefix` here, but it's too long for the db schema
       // field, so we just write elk (lowercase in protest :P ).
       this.append("version", "elk")

--- a/emulinker/src/main/java/org/emulinker/kaillera/master/client/KailleraMasterUpdateTask.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/master/client/KailleraMasterUpdateTask.kt
@@ -41,7 +41,7 @@ constructor(
       this.append("servername", publicInfo.serverName)
       this.append("port", flags.serverPort.toString())
       this.append("nbusers", kailleraServer.users.size.toString())
-      this.append("maxconn", kailleraServer.maxUsers.toString())
+      this.append("maxconn", flags.maxUsers.toString())
       // I want to use `releaseInfo.versionWithElkPrefix` here, but it's too long for the db schema
       // field, so we just write elk (lowercase in protest :P ).
       this.append("version", "elk")

--- a/emulinker/src/main/java/org/emulinker/kaillera/pico/AppModule.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/pico/AppModule.kt
@@ -14,6 +14,7 @@ import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 import javax.inject.Named
 import javax.inject.Singleton
+import kotlinx.datetime.Clock
 import org.apache.commons.configuration.Configuration
 import org.emulinker.config.RuntimeFlags
 import org.emulinker.config.RuntimeFlags.Companion.loadFromApacheConfiguration
@@ -107,17 +108,11 @@ abstract class AppModule {
       )
 
     // TODO(nue): We should probably be using TaskScheduler instead?
-    @Provides
-    @Singleton
-    fun provideTimer(): Timer {
-      return Timer(/* isDaemon= */ true)
-    }
+    @Provides @Singleton fun provideTimer(): Timer = Timer(/* isDaemon= */ true)
 
-    @Provides
-    @Singleton
-    fun provideMetricRegistry(): MetricRegistry {
-      return MetricRegistry()
-    }
+    @Provides @Singleton fun provideMetricRegistry(): MetricRegistry = MetricRegistry()
+
+    @Provides @Singleton fun provideClock(): Clock = Clock.System
 
     @Provides
     @Singleton


### PR DESCRIPTION
Also:
- Some performance improvements
- Using `kotlinx-datetime` for dates/instants/clocks
- Non-game owners can also use `/lagstat` now (though not `/lagreset` yet)
- Some changes to how activity and ping timeouts are calculated, we will need to test to make sure there are no bugs.