### PR TITLE
Bring back legacy lagstat, some lag exprimentation, performance improvements

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.9.23" />
+    <option name="version" value="2.0.20" />
   </component>
 </project>

--- a/emulinker/build.gradle.kts
+++ b/emulinker/build.gradle.kts
@@ -1,14 +1,14 @@
 import java.time.Instant
 
 plugins {
-  id("com.diffplug.spotless") version "6.18.0"
-  id("org.jetbrains.dokka") version "1.8.10"
+  id("com.diffplug.spotless") version "6.25.0"
+  id("org.jetbrains.dokka") version "1.9.20"
   application
 
-  kotlin("jvm") version "1.9.23"
-  kotlin("plugin.serialization") version "1.8.21"
+  kotlin("jvm") version "2.0.20"
+  kotlin("plugin.serialization") version "2.0.20"
 
-  id("com.google.devtools.ksp") version "1.9.23-1.0.20"
+  id("com.google.devtools.ksp") version "2.0.20-1.0.24"
 }
 
 repositories {
@@ -17,32 +17,35 @@ repositories {
 }
 
 dependencies {
-  api("org.jetbrains.kotlin:kotlin-stdlib:1.8.21")
+  api("org.jetbrains.kotlin:kotlin-stdlib:2.0.20")
 
   implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.1")
 
-  implementation("io.github.redouane59.twitter:twittered:2.22")
+  implementation("io.github.redouane59.twitter:twittered:2.23")
 
   api("io.dropwizard.metrics:metrics-core:4.2.3")
   api("io.dropwizard.metrics:metrics-jvm:4.2.3")
 
-  api("com.google.flogger:flogger:0.7.4")
-  api("com.google.flogger:flogger-system-backend:0.7.4")
-  api("com.google.flogger:flogger-log4j2-backend:0.7.4")
+  val floggerVersion = "0.8"
+  api("com.google.flogger:flogger:$floggerVersion")
+  api("com.google.flogger:flogger-system-backend:$floggerVersion")
+  api("com.google.flogger:flogger-log4j2-backend:$floggerVersion")
 
-  implementation("com.google.dagger:dagger:2.51.1")
-  implementation("com.google.dagger:dagger-compiler:2.51.1")
-  ksp("com.google.dagger:dagger-compiler:2.51.1")
+  val daggerVersion = "2.52"
+  implementation("com.google.dagger:dagger:$daggerVersion")
+  implementation("com.google.dagger:dagger-compiler:$daggerVersion")
+  ksp("com.google.dagger:dagger-compiler:$daggerVersion")
 
-  api("org.apache.logging.log4j:log4j:2.20.0")
-  api("org.apache.logging.log4j:log4j-core:2.20.0")
-  api("org.apache.logging.log4j:log4j-api:2.20.0")
+  val log4j = "2.23.1"
+  api("org.apache.logging.log4j:log4j:$log4j")
+  api("org.apache.logging.log4j:log4j-core:$log4j")
+  api("org.apache.logging.log4j:log4j-api:$log4j")
 
   api("org.mortbay.jetty:jetty:4.2.12")
   api("commons-configuration:commons-configuration:1.1")
   api("commons-pool:commons-pool:1.2")
 
-  val ktorVersion = "2.3.9"
+  val ktorVersion = "2.3.12"
   implementation("io.ktor:ktor-network-jvm:$ktorVersion")
   implementation("io.ktor:ktor-server-core-jvm:$ktorVersion")
   implementation("io.ktor:ktor-server-netty-jvm:$ktorVersion")
@@ -52,13 +55,13 @@ dependencies {
   implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.6.1")
 
   // This is only used by the fake testing client, hopefully we can remove this.
-  testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.1")
+  testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1")
 
   testImplementation("junit:junit:4.13.2")
-  testImplementation("com.google.truth:truth:1.1.3")
+  testImplementation("com.google.truth:truth:1.4.4")
   testImplementation(kotlin("test"))
-  testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4")
-  testImplementation("org.mockito.kotlin:mockito-kotlin:4.1.0")
+  testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1")
+  testImplementation("org.mockito.kotlin:mockito-kotlin:5.4.0")
 }
 
 group = "org.emulinker"

--- a/emulinker/src/main/java-templates/org/emulinker/kaillera/pico/CompiledFlags.kt
+++ b/emulinker/src/main/java-templates/org/emulinker/kaillera/pico/CompiledFlags.kt
@@ -1,6 +1,6 @@
 package org.emulinker.kaillera.pico
 
-import java.time.Instant
+import kotlinx.datetime.Instant
 
 /** Constants inserted at compile time. */
 object CompiledFlags {
@@ -12,7 +12,7 @@ object CompiledFlags {
 
   const val PROJECT_URL: String = "${project.url}"
 
-  val BUILD_DATE: Instant = Instant.ofEpochSecond(${buildTimestampSeconds})
+  val BUILD_DATE: Instant = Instant.fromEpochSeconds(${buildTimestampSeconds})
 
   const val USE_BYTEREADPACKET_INSTEAD_OF_BYTEBUFFER: Boolean = ${useBytereadpacketInsteadOfBytebuffer}
 

--- a/emulinker/src/main/java/org/emulinker/config/RuntimeFlags.kt
+++ b/emulinker/src/main/java/org/emulinker/config/RuntimeFlags.kt
@@ -4,6 +4,7 @@ import java.nio.charset.Charset
 import javax.inject.Singleton
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 import org.apache.commons.configuration.Configuration
 
@@ -25,6 +26,7 @@ data class RuntimeFlags(
   val gameTimeout: Duration,
   val idleTimeout: Duration,
   val keepAliveTimeout: Duration,
+  val lagstatDuration: Duration,
   val maxChatLength: Int,
   val maxClientNameLength: Int,
   val maxGameChatLength: Int,
@@ -36,6 +38,7 @@ data class RuntimeFlags(
   val maxUsers: Int,
   val metricsEnabled: Boolean,
   val metricsLoggingFrequency: Duration,
+  val nettyFlags: Int,
   val serverAddress: String,
   val serverLocation: String,
   val serverName: String,
@@ -52,7 +55,6 @@ data class RuntimeFlags(
   val twitterOAuthConsumerSecret: String,
   val twitterPreventBroadcastNameSuffixes: List<String>,
   val v086BufferSize: Int,
-  val nettyFlags: Int,
 ) {
 
   init {
@@ -66,7 +68,7 @@ data class RuntimeFlags(
     require(keepAliveTimeout.isPositive()) {
       "server.keepAliveTimeout must be > 0 (190 is recommended)"
     }
-
+    require(lagstatDuration.isPositive()) { "server.lagstatDurationSeconds must be positive" }
     require(gameBufferSize > 0) { "game.bufferSize can not be <= 0" }
     require(gameTimeout.isPositive()) { "game.timeoutMillis can not be <= 0" }
     require(gameAutoFireSensitivity in 0..5) { "game.defaultAutoFireSensitivity must be 0-5" }
@@ -99,6 +101,8 @@ data class RuntimeFlags(
         gameTimeout = config.getInt("game.timeoutMillis").milliseconds,
         idleTimeout = config.getInt("server.idleTimeout").seconds,
         keepAliveTimeout = config.getInt("server.keepAliveTimeout").seconds,
+        lagstatDuration =
+          config.getInt("server.lagstatDurationSeconds", 3.minutes.inWholeSeconds.toInt()).seconds,
         maxChatLength = config.getInt("server.maxChatLength"),
         maxClientNameLength = config.getInt("server.maxClientNameLength"),
         maxGameChatLength = config.getInt("server.maxGameChatLength"),
@@ -110,6 +114,8 @@ data class RuntimeFlags(
         maxUsers = config.getInt("server.maxUsers"),
         metricsEnabled = config.getBoolean("metrics.enabled", false),
         metricsLoggingFrequency = config.getInt("metrics.loggingFrequencySeconds", 30).seconds,
+        // TODO(nue): This default works well, but maybe we can experiment further.
+        nettyFlags = config.getInt("server.nettyThreadpoolSize", 30),
         serverAddress = config.getString("masterList.serverConnectAddress", ""),
         serverLocation = config.getString("masterList.serverLocation", "Unknown"),
         serverName = config.getString("masterList.serverName", "Emulinker Server"),
@@ -127,8 +133,6 @@ data class RuntimeFlags(
         twitterPreventBroadcastNameSuffixes =
           config.getStringArray("twitter.preventBroadcastNameSuffixes").toList(),
         v086BufferSize = config.getInt("controllers.v086.bufferSize", 4096),
-        // TODO(nue): This default works well, but maybe we can experiment further.
-        nettyFlags = config.getInt("server.nettyThreadpoolSize", 30),
       )
     }
   }

--- a/emulinker/src/main/java/org/emulinker/kaillera/access/AccessManager.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/access/AccessManager.kt
@@ -77,7 +77,9 @@ interface AccessManager : Closeable {
    * @param minutes Number of minutes this grant is valid from the time of addition
    */
   fun addTempAdmin(addressPattern: String, duration: Duration)
+
   fun addTempModerator(addressPattern: String, duration: Duration)
+
   fun addTempElevated(addressPattern: String, duration: Duration)
 
   /**
@@ -88,6 +90,7 @@ interface AccessManager : Closeable {
    * @param minutes Number of minutes this grant is valid from the time of addition
    */
   fun addSilenced(addressPattern: String, duration: Duration)
+
   fun clearTemp(address: InetAddress, clearAll: Boolean): Boolean
 
   companion object {

--- a/emulinker/src/main/java/org/emulinker/kaillera/access/AccessManager2.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/access/AccessManager2.kt
@@ -230,6 +230,7 @@ internal constructor(private val flags: RuntimeFlags, private val taskScheduler:
     private var resolvedAddresses: MutableList<String>
     var access = 0
       private set
+
     var message: String? = null
       private set
 

--- a/emulinker/src/main/java/org/emulinker/kaillera/admin/AdminServer.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/admin/AdminServer.kt
@@ -2,5 +2,6 @@ package org.emulinker.kaillera.admin
 
 interface AdminServer {
   fun start()
+
   fun stop()
 }

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/V086ClientHandler.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/V086ClientHandler.kt
@@ -258,6 +258,7 @@ constructor(
         val m: V086Message = messages[0]!!
         lastMessageNumber = m.messageNumber
         val messageTypeId = m.messageTypeId
+
         val action: V086Action<out V086Message>? =
           // Checking for GameData first is a speed optimization.
           if (messageTypeId == GameData.ID) {

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/V086ClientHandler.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/V086ClientHandler.kt
@@ -91,10 +91,13 @@ constructor(
 
   private var prevMessageNumber = -1
     private set
+
   private var lastMessageNumber = -1
     private set
+
   var clientGameDataCache: GameDataCache = ClientGameDataCache(256)
     private set
+
   var serverGameDataCache: GameDataCache = ClientGameDataCache(256)
     private set
 
@@ -104,8 +107,10 @@ constructor(
   private var lastMeasurement: Long = 0
   var speedMeasurementCount = 0
     private set
+
   var bestNetworkSpeed = Int.MAX_VALUE
     private set
+
   private var clientRetryCount = 0
   private var lastResend = 0L
 
@@ -230,8 +235,7 @@ constructor(
             .log("%s received invalid message: %s}", this, EmuUtil.dumpBuffer(newBuffer))
           null
         }
-      }
-        ?: return
+      } ?: return
 
     stripFromProdBinary {
       logger.atFinest().log("<- FROM P%d: %s", user.id, inBundle.messages.firstOrNull())

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/V086ClientHandler.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/V086ClientHandler.kt
@@ -45,7 +45,6 @@ class V086ClientHandler
 constructor(
   metrics: MetricRegistry,
   private val flags: RuntimeFlags,
-  private val gameDataAction: GameDataAction,
   // TODO(nue): Try to replace this with remoteSocketAddress.
   /** I think this is the address from when the user called the connect controller. */
   @Assisted val connectRemoteSocketAddress: InetSocketAddress,
@@ -262,7 +261,7 @@ constructor(
         val action: V086Action<out V086Message>? =
           // Checking for GameData first is a speed optimization.
           if (messageTypeId == GameData.ID) {
-            gameDataAction
+            GameDataAction
           } else {
             controller.actions[m.messageTypeId.toInt()]
           }
@@ -298,7 +297,7 @@ constructor(
           val action: V086Action<out V086Message>? =
             // Checking for GameData first is a speed optimization.
             if (messageTypeId == GameData.ID) {
-              gameDataAction
+              GameDataAction
             } else {
               controller.actions[m.messageTypeId.toInt()]
             }
@@ -320,7 +319,7 @@ constructor(
     when (event) {
       // Check for GameDataEvent first to avoid map lookup slowness.
       is GameDataEvent -> {
-        gameDataAction.handleEvent(event, this)
+        GameDataAction.handleEvent(event, this)
       }
       is GameEvent -> {
         val eventHandler = controller.gameEventHandlers[event::class]

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/V086Controller.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/V086Controller.kt
@@ -96,8 +96,6 @@ internal constructor(
   gameChatAction: GameChatAction,
   gameKickAction: GameKickAction,
   userReadyAction: UserReadyAction,
-  cachedGameDataAction: CachedGameDataAction,
-  gameDataAction: GameDataAction,
   dropGameAction: DropGameAction,
   closeGameAction: CloseGameAction,
   gameStatusAction: GameStatusAction,
@@ -131,7 +129,7 @@ internal constructor(
       GameStartedEvent::class to startGameAction,
       GameChatEvent::class to gameChatAction,
       AllReadyEvent::class to userReadyAction,
-      GameDataEvent::class to gameDataAction,
+      GameDataEvent::class to GameDataAction,
       UserDroppedGameEvent::class to dropGameAction,
       GameDesynchEvent::class to gameDesynchAction,
       PlayerDesynchEvent::class to playerDesynchAction,
@@ -205,8 +203,8 @@ internal constructor(
     actions[GameChat.ID.toInt()] = gameChatAction
     actions[GameKick.ID.toInt()] = gameKickAction
     actions[AllReady.ID.toInt()] = userReadyAction
-    actions[CachedGameData.ID.toInt()] = cachedGameDataAction
-    actions[GameData.ID.toInt()] = gameDataAction
+    actions[CachedGameData.ID.toInt()] = CachedGameDataAction
+    actions[GameData.ID.toInt()] = GameDataAction
     actions[PlayerDrop.ID.toInt()] = dropGameAction
   }
 

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/ACKAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/ACKAction.kt
@@ -21,6 +21,7 @@ class ACKAction @Inject internal constructor() :
   V086Action<ClientAck>, V086UserEventHandler<UserEvent> {
   override var actionPerformedCount = 0
     private set
+
   override var handledEventCount = 0
     private set
 

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/ACKAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/ACKAction.kt
@@ -84,7 +84,7 @@ class ACKAction @Inject internal constructor() :
     val users = mutableListOf<ServerStatus.User>()
     val games = mutableListOf<ServerStatus.Game>()
     try {
-      for (user in server.users) {
+      for (user in server.usersMap.values) {
         if (user.status != UserStatus.CONNECTING && user != thisUser)
           users.add(
             ServerStatus.User(
@@ -101,7 +101,7 @@ class ACKAction @Inject internal constructor() :
       return
     }
     try {
-      for (game in server.games) {
+      for (game in server.gamesMap.values) {
         var num = 0
         for (user in game.players) {
           if (!user.inStealthMode) num++

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/AdminCommandAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/AdminCommandAction.kt
@@ -332,7 +332,7 @@ class AdminCommandAction @Inject internal constructor() : V086Action<Chat> {
     var foundCount = 0
     val str = message.substring(space + 1)
     // WildcardStringPattern pattern = new WildcardStringPattern
-    for (user in server.users) {
+    for (user in server.usersMap.values) {
       if (!user.loggedIn) continue
       if (user.name!!.lowercase(Locale.getDefault()).contains(str.lowercase(Locale.getDefault()))) {
         var msg =
@@ -365,7 +365,7 @@ class AdminCommandAction @Inject internal constructor() : V086Action<Chat> {
     if (space < 0) throw ActionException(EmuLang.getString("AdminCommandAction.FindGameError"))
     var foundCount = 0
     val pattern = WildcardStringPattern(message.substring(space + 1))
-    for (game in server.games) {
+    for (game in server.gamesMap.values) {
       if (pattern.match(game.romName)) {
         val sb = StringBuilder()
         sb.append("GameID: ")

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/AdminCommandAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/AdminCommandAction.kt
@@ -24,6 +24,7 @@ import org.emulinker.kaillera.model.impl.Trivia
 import org.emulinker.util.EmuLang
 import org.emulinker.util.EmuUtil
 import org.emulinker.util.EmuUtil.threadSleep
+import org.emulinker.util.EmuUtil.toSimpleUtcDatetime
 import org.emulinker.util.WildcardStringPattern
 
 @Singleton
@@ -889,7 +890,7 @@ class AdminCommandAction @Inject internal constructor() : V086Action<Chat> {
             ": " +
             releaseInfo.version +
             ": " +
-            EmuUtil.toSimpleUtcDatetime(releaseInfo.buildDate)
+            releaseInfo.buildDate.toSimpleUtcDatetime()
         )
       )
       threadSleep(20.milliseconds)

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/AdminCommandAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/AdminCommandAction.kt
@@ -29,6 +29,7 @@ import org.emulinker.util.WildcardStringPattern
 @Singleton
 class AdminCommandAction @Inject internal constructor() : V086Action<Chat> {
   override val actionPerformedCount = 0
+
   override fun toString() = "AdminCommandAction"
 
   fun isValidCommand(chat: String): Boolean {

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/CachedGameDataAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/CachedGameDataAction.kt
@@ -2,8 +2,6 @@ package org.emulinker.kaillera.controller.v086.action
 
 import com.google.common.flogger.FluentLogger
 import java.lang.IndexOutOfBoundsException
-import javax.inject.Inject
-import javax.inject.Singleton
 import kotlin.Throws
 import org.emulinker.kaillera.controller.messaging.MessageFormatException
 import org.emulinker.kaillera.controller.v086.V086ClientHandler
@@ -12,8 +10,7 @@ import org.emulinker.kaillera.controller.v086.protocol.GameChatNotification
 import org.emulinker.kaillera.controller.v086.protocol.GameData.Companion.create
 import org.emulinker.kaillera.model.exception.GameDataException
 
-@Singleton
-class CachedGameDataAction @Inject internal constructor() : V086Action<CachedGameData> {
+object CachedGameDataAction : V086Action<CachedGameData> {
   override val actionPerformedCount = 0
 
   override fun toString() = "CachedGameDataAction"
@@ -65,7 +62,5 @@ class CachedGameDataAction @Inject internal constructor() : V086Action<CachedGam
     }
   }
 
-  companion object {
-    private val logger = FluentLogger.forEnclosingClass()
-  }
+  private val logger = FluentLogger.forEnclosingClass()
 }

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/CachedGameDataAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/CachedGameDataAction.kt
@@ -20,40 +20,47 @@ class CachedGameDataAction @Inject internal constructor() : V086Action<CachedGam
 
   @Throws(FatalActionException::class)
   override fun performAction(message: CachedGameData, clientHandler: V086ClientHandler) {
-    try {
-      val user = clientHandler.user
-      val data = clientHandler.clientGameDataCache[message.key]
-      if (data == null) {
-        logger.atFine().log("Game Cache Error: null data")
-        return
-      }
-      user.addGameData(data)
-    } catch (e: GameDataException) {
-      logger.atFine().withCause(e).log("Game data error")
-      if (e.response != null) {
-        try {
-          clientHandler.send(create(clientHandler.nextMessageNumber, e.response!!))
-        } catch (e2: MessageFormatException) {
-          logger.atSevere().withCause(e2).log("Failed to construct GameData message")
+    val user = clientHandler.user
+    val data = clientHandler.clientGameDataCache[message.key]
+    if (data == null) {
+      logger.atFine().log("Game Cache Error: null data")
+      return
+    }
+    user.addGameData(data).onFailure { e ->
+      when (e) {
+        is GameDataException -> {
+          logger.atFine().withCause(e).log("Game data error")
+          if (e.response != null) {
+            try {
+              clientHandler.send(create(clientHandler.nextMessageNumber, e.response!!))
+            } catch (e2: MessageFormatException) {
+              logger.atSevere().withCause(e2).log("Failed to construct GameData message")
+            }
+          }
         }
-      }
-    } catch (e: IndexOutOfBoundsException) {
-      logger
-        .atSevere()
-        .withCause(e)
-        .log("Game data error!  The client cached key %s was not found in the cache!", message.key)
+        is IndexOutOfBoundsException -> {
+          logger
+            .atSevere()
+            .withCause(e)
+            .log(
+              "Game data error!  The client cached key %s was not found in the cache!",
+              message.key
+            )
 
-      // This may not always be the best thing to do...
-      try {
-        clientHandler.send(
-          GameChatNotification(
-            clientHandler.nextMessageNumber,
-            "Error",
-            "Game Data Error!  Game state will be inconsistent!"
-          )
-        )
-      } catch (e2: MessageFormatException) {
-        logger.atSevere().withCause(e2).log("Failed to construct new GameChat.Notification")
+          // This may not always be the best thing to do...
+          try {
+            clientHandler.send(
+              GameChatNotification(
+                clientHandler.nextMessageNumber,
+                "Error",
+                "Game Data Error!  Game state will be inconsistent!"
+              )
+            )
+          } catch (e2: MessageFormatException) {
+            logger.atSevere().withCause(e2).log("Failed to construct new GameChat.Notification")
+          }
+        }
+        else -> throw e
       }
     }
   }

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/CachedGameDataAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/CachedGameDataAction.kt
@@ -15,6 +15,7 @@ import org.emulinker.kaillera.model.exception.GameDataException
 @Singleton
 class CachedGameDataAction @Inject internal constructor() : V086Action<CachedGameData> {
   override val actionPerformedCount = 0
+
   override fun toString() = "CachedGameDataAction"
 
   @Throws(FatalActionException::class)

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/ChatAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/ChatAction.kt
@@ -17,8 +17,8 @@ import org.emulinker.kaillera.controller.v086.protocol.InformationMessage
 import org.emulinker.kaillera.model.event.ChatEvent
 import org.emulinker.kaillera.model.exception.ActionException
 import org.emulinker.util.EmuLang
-import org.emulinker.util.EmuUtil
 import org.emulinker.util.EmuUtil.threadSleep
+import org.emulinker.util.EmuUtil.toSimpleUtcDatetime
 
 private const val ADMIN_COMMAND_ESCAPE_STRING = "/"
 
@@ -106,7 +106,7 @@ class ChatAction @Inject internal constructor(private val adminCommandAction: Ad
             InformationMessage(
               clientHandler.nextMessageNumber,
               "server",
-              "VERSION: ${releaseInfo.productName}: ${releaseInfo.version}: ${EmuUtil.toSimpleUtcDatetime(releaseInfo.buildDate)}"
+              "VERSION: ${releaseInfo.productName}: ${releaseInfo.version}: ${releaseInfo.buildDate.toSimpleUtcDatetime()}"
             )
           )
         } catch (e: Exception) {}

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/ChatAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/ChatAction.kt
@@ -27,6 +27,7 @@ class ChatAction @Inject internal constructor(private val adminCommandAction: Ad
   V086Action<ChatRequest>, V086ServerEventHandler<ChatEvent> {
   override var actionPerformedCount = 0
     private set
+
   override var handledEventCount = 0
     private set
 

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/CreateGameAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/CreateGameAction.kt
@@ -23,6 +23,7 @@ internal constructor(@param:Named("joinGameMessages") private val joinGameMessag
   V086Action<CreateGame>, V086ServerEventHandler<GameCreatedEvent> {
   override var actionPerformedCount = 0
     private set
+
   override var handledEventCount = 0
     private set
 

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/DropGameAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/DropGameAction.kt
@@ -15,6 +15,7 @@ class DropGameAction @Inject internal constructor() :
   V086Action<PlayerDropRequest>, V086GameEventHandler<UserDroppedGameEvent> {
   override var actionPerformedCount = 0
     private set
+
   override var handledEventCount = 0
     private set
 

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/FatalActionException.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/FatalActionException.kt
@@ -2,5 +2,6 @@ package org.emulinker.kaillera.controller.v086.action
 
 class FatalActionException : Exception {
   constructor(message: String?) : super(message)
+
   constructor(message: String?, source: Exception?) : super(message, source)
 }

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameChatAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameChatAction.kt
@@ -25,6 +25,7 @@ internal constructor(
 ) : V086Action<GameChatRequest>, V086GameEventHandler<GameChatEvent> {
   override var actionPerformedCount = 0
     private set
+
   override var handledEventCount = 0
     private set
 
@@ -492,9 +493,7 @@ internal constructor(
           .asSequence()
           .filter { !it.inStealthMode }
           .forEach {
-            clientHandler.user.game!!.announce(
-              "P${it.playerNumber}: ${it.smallLagSpikesCausedByUser} (tiny), ${it.bigLagSpikesCausedByUser} (big)"
-            )
+            clientHandler.user.game!!.announce("P${it.playerNumber}: ${it.summarizeLag()}")
           }
       } else
         clientHandler.user.game!!.announce(

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameChatAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameChatAction.kt
@@ -463,7 +463,8 @@ internal constructor(
           .forEach { game.announce("P${it.playerNumber}: ${it.summarizeLag()}") }
         game.announce(
           "Overall game drift: " +
-            (game.totalDriftNs.nanoseconds - game.totalDriftCache.getDelayedValue().nanoseconds)
+            (game.totalDriftNs.nanoseconds -
+                (game.totalDriftCache.getDelayedValue() ?: 0).nanoseconds)
               .absoluteValue
         )
       } else if (message.message == "/lagreset") {

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameChatAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameChatAction.kt
@@ -487,7 +487,9 @@ internal constructor(
         }
       } else if (message.message == "/lagstat") {
         // Note: This was duplicated from GameOwnerCommandAction.
-        clientHandler.user.game!!.announce("Lagged frames per player:")
+        clientHandler.user.game!!.announce(
+          "Lagged frames per player by delay (small may contain false positives):"
+        )
         clientHandler.user.game!!
           .players
           .asSequence()

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameChatAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameChatAction.kt
@@ -58,9 +58,10 @@ internal constructor(
   }
 
   @Throws(FatalActionException::class)
-  private fun checkCommands(message: V086Message, clientHandler: V086ClientHandler?) {
+  private fun checkCommands(message: V086Message, clientHandler: V086ClientHandler) {
     var doCommand = true
-    if (clientHandler!!.user.accessLevel < AccessManager.ACCESS_ELEVATED) {
+    val game = checkNotNull(clientHandler.user.game)
+    if (clientHandler.user.accessLevel < AccessManager.ACCESS_ELEVATED) {
       try {
         clientHandler.user.chat(":USER_COMMAND")
       } catch (e: ActionException) {
@@ -71,20 +72,20 @@ internal constructor(
       if ((message as GameChat).message == "/msgon") {
         try {
           clientHandler.user.isAcceptingDirectMessages = true
-          clientHandler.user.game!!.announce("Private messages are now on.", clientHandler.user)
+          game.announce("Private messages are now on.", clientHandler.user)
         } catch (e: Exception) {}
         return
       } else if (message.message == "/msgoff") {
         try {
           clientHandler.user.isAcceptingDirectMessages = false
-          clientHandler.user.game!!.announce("Private messages are now off.", clientHandler.user)
+          game.announce("Private messages are now off.", clientHandler.user)
         } catch (e: Exception) {}
         return
       } else if (message.message.startsWith("/p2p")) {
         if (message.message == "/p2pon") {
-          if (clientHandler.user.game!!.owner == clientHandler.user) {
-            clientHandler.user.game!!.ignoringUnnecessaryServerActivity = true
-            for (u in clientHandler.user.game!!.players) {
+          if (game.owner == clientHandler.user) {
+            game.ignoringUnnecessaryServerActivity = true
+            for (u in game.players) {
               u.ignoringUnnecessaryServerActivity = true
               if (u.loggedIn) {
                 u.game!!.announce(
@@ -95,7 +96,7 @@ internal constructor(
             }
           } else {
             clientHandler.user.ignoringUnnecessaryServerActivity = true
-            for (u in clientHandler.user.game!!.players) {
+            for (u in game.players) {
               if (u.loggedIn) {
                 u.game!!.announce(
                   "${clientHandler.user.name} will NOT receive any server activity during gameplay!",
@@ -105,9 +106,9 @@ internal constructor(
             }
           }
         } else if (message.message == "/p2poff") {
-          if (clientHandler.user.game!!.owner == clientHandler.user) {
-            clientHandler.user.game!!.ignoringUnnecessaryServerActivity = false
-            for (u in clientHandler.user.game!!.players) {
+          if (game.owner == clientHandler.user) {
+            game.ignoringUnnecessaryServerActivity = false
+            for (u in game.players) {
               u.ignoringUnnecessaryServerActivity = false
               if (u.loggedIn) {
                 u.game!!.announce(
@@ -118,7 +119,7 @@ internal constructor(
             }
           } else {
             clientHandler.user.ignoringUnnecessaryServerActivity = false
-            for (u in clientHandler.user.game!!.players) {
+            for (u in game.players) {
               if (u.loggedIn) {
                 u.game!!.announce(
                   clientHandler.user.name +
@@ -129,7 +130,7 @@ internal constructor(
             }
           }
         } else {
-          clientHandler.user.game!!.announce("Failed P2P: /p2pon or /p2poff", clientHandler.user)
+          game.announce("Failed P2P: /p2pon or /p2poff", clientHandler.user)
         }
         return
       } else if (message.message.startsWith("/msg")) {
@@ -144,7 +145,7 @@ internal constructor(
               clientHandler.user.socketAddress!!.address
             )
         ) {
-          clientHandler.user.game!!.announce("You are silenced!", clientHandler.user)
+          game.announce("You are silenced!", clientHandler.user)
           return
         }
         try {
@@ -157,25 +158,22 @@ internal constructor(
             sb.append(" ")
           }
           if (user == null) {
-            clientHandler.user.game!!.announce("User not found!", clientHandler.user)
+            game.announce("User not found!", clientHandler.user)
             return
           }
           if (user.game != clientHandler.user.game) {
-            clientHandler.user.game!!.announce("User not in this game!", clientHandler.user)
+            game.announce("User not in this game!", clientHandler.user)
             return
           }
           if (user === clientHandler.user) {
-            clientHandler.user.game!!.announce(
-              "You can't private message yourself!",
-              clientHandler.user
-            )
+            game.announce("You can't private message yourself!", clientHandler.user)
             return
           }
           if (
             !user.isAcceptingDirectMessages ||
               user.searchIgnoredUsers(clientHandler.user.connectSocketAddress.address.hostAddress)
           ) {
-            clientHandler.user.game!!.announce(
+            game.announce(
               "<" + user.name + "> Is not accepting private messages!",
               clientHandler.user
             )
@@ -189,7 +187,7 @@ internal constructor(
             for (i in chars.indices) {
               if (chars[i].code < 32) {
                 logger.atWarning().log("%s /msg denied: Illegal characters in message", user)
-                clientHandler.user.game!!.announce(
+                game.announce(
                   "Private Message Denied: Illegal characters in message",
                   clientHandler.user
                 )
@@ -198,10 +196,7 @@ internal constructor(
             }
             if (m.length > 320) {
               logger.atWarning().log("%s /msg denied: Message Length > 320", user)
-              clientHandler.user.game!!.announce(
-                "Private Message Denied: Message Too Long",
-                clientHandler.user
-              )
+              game.announce("Private Message Denied: Message Too Long", clientHandler.user)
               return
             }
           }
@@ -229,18 +224,15 @@ internal constructor(
                 sb.append(" ")
               }
               if (user == null) {
-                clientHandler.user.game!!.announce("User not found!", clientHandler.user)
+                game.announce("User not found!", clientHandler.user)
                 return
               }
               if (user.game != clientHandler.user.game) {
-                clientHandler.user.game!!.announce("User not in this game!", clientHandler.user)
+                game.announce("User not in this game!", clientHandler.user)
                 return
               }
               if (user === clientHandler.user) {
-                clientHandler.user.game!!.announce(
-                  "You can't private message yourself!",
-                  clientHandler.user
-                )
+                game.announce("You can't private message yourself!", clientHandler.user)
                 return
               }
               var m = sb.toString()
@@ -252,7 +244,7 @@ internal constructor(
                 while (i < chars.size) {
                   if (chars[i].code < 32) {
                     logger.atWarning().log("%s /msg denied: Illegal characters in message", user)
-                    clientHandler.user.game!!.announce(
+                    game.announce(
                       "Private Message Denied: Illegal characters in message",
                       clientHandler.user
                     )
@@ -262,10 +254,7 @@ internal constructor(
                 }
                 if (m.length > 320) {
                   logger.atWarning().log("%s /msg denied: Message Length > 320", user)
-                  clientHandler.user.game!!.announce(
-                    "Private Message Denied: Message Too Long",
-                    clientHandler.user
-                  )
+                  game.announce("Private Message Denied: Message Too Long", clientHandler.user)
                   return
                 }
               }
@@ -275,7 +264,7 @@ internal constructor(
               // + m, false, user1);
               // user.getServer().announce("<" + clientHandler.getUser().getName() + "> (" +
               // clientHandler.getUser().getID() + "): " + m, false, user);
-              clientHandler.user.game?.announce(
+              game.announce(
                 "TO: <${user.name}>(${user.id}) <${clientHandler.user.name}> (${clientHandler.user.id}): $m",
                 clientHandler.user
               )
@@ -285,17 +274,11 @@ internal constructor(
               )
               return
             } catch (e1: Exception) {
-              clientHandler.user.game!!.announce(
-                "Private Message Error: /msg <UserID> <message>",
-                clientHandler.user
-              )
+              game.announce("Private Message Error: /msg <UserID> <message>", clientHandler.user)
               return
             }
           } else {
-            clientHandler.user.game!!.announce(
-              "Private Message Error: /msg <UserID> <message>",
-              clientHandler.user
-            )
+            game.announce("Private Message Error: /msg <UserID> <message>", clientHandler.user)
             return
           }
         }
@@ -326,25 +309,19 @@ internal constructor(
           val userID = scanner.nextInt()
           val user = clientHandler.user.server.getUser(userID)
           if (user == null) {
-            clientHandler.user.game!!.announce("User not found!", clientHandler.user)
+            game.announce("User not found!", clientHandler.user)
             return
           }
           if (user === clientHandler.user) {
-            clientHandler.user.game!!.announce("You can't ignore yourself!", clientHandler.user)
+            game.announce("You can't ignore yourself!", clientHandler.user)
             return
           }
           if (clientHandler.user.findIgnoredUser(user.connectSocketAddress.address.hostAddress)) {
-            clientHandler.user.game!!.announce(
-              "You can't ignore a user that is already ignored!",
-              clientHandler.user
-            )
+            game.announce("You can't ignore a user that is already ignored!", clientHandler.user)
             return
           }
           if (user.accessLevel >= AccessManager.ACCESS_MODERATOR) {
-            clientHandler.user.game!!.announce(
-              "You cannot ignore a moderator or admin!",
-              clientHandler.user
-            )
+            game.announce("You cannot ignore a moderator or admin!", clientHandler.user)
             return
           }
           clientHandler.user.addIgnoredUser(user.connectSocketAddress.address.hostAddress)
@@ -355,10 +332,7 @@ internal constructor(
           )
           return
         } catch (e: NoSuchElementException) {
-          clientHandler.user.game!!.announce(
-            "Ignore User Error: /ignore <UserID>",
-            clientHandler.user
-          )
+          game.announce("Ignore User Error: /ignore <UserID>", clientHandler.user)
           logger
             .atInfo()
             .withCause(e)
@@ -376,14 +350,11 @@ internal constructor(
           val userID = scanner.nextInt()
           val user = clientHandler.user.server.getUser(userID)
           if (user == null) {
-            clientHandler.user.game!!.announce("User Not Found!", clientHandler.user)
+            game.announce("User Not Found!", clientHandler.user)
             return
           }
           if (!clientHandler.user.findIgnoredUser(user.connectSocketAddress.address.hostAddress)) {
-            clientHandler.user.game!!.announce(
-              "You can't unignore a user that isn't ignored",
-              clientHandler.user
-            )
+            game.announce("You can't unignore a user that isn't ignored", clientHandler.user)
             return
           }
           if (
@@ -405,10 +376,7 @@ internal constructor(
             } catch (e: Exception) {}
           return
         } catch (e: NoSuchElementException) {
-          clientHandler.user.game!!.announce(
-            "Unignore User Error: /ignore <UserID>",
-            clientHandler.user
-          )
+          game.announce("Unignore User Error: /ignore <UserID>", clientHandler.user)
           logger
             .atInfo()
             .withCause(e)
@@ -422,7 +390,7 @@ internal constructor(
       } else if (message.message.startsWith("/me")) {
         val space = message.message.indexOf(' ')
         if (space < 0) {
-          clientHandler.user.game!!.announce("Invalid # of Fields!", clientHandler.user)
+          game.announce("Invalid # of Fields!", clientHandler.user)
           return
         }
         var announcement = message.message.substring(space + 1)
@@ -441,41 +409,41 @@ internal constructor(
               clientHandler.user.socketAddress!!.address
             )
         ) {
-          clientHandler.user.game!!.announce("You are silenced!", clientHandler.user)
+          game.announce("You are silenced!", clientHandler.user)
           return
         }
         if (clientHandler.user.server.checkMe(clientHandler.user, announcement)) {
           val m = announcement
           announcement = "*" + clientHandler.user.name + " " + m
-          for (user in clientHandler.user.game!!.players) {
+          for (user in game.players) {
             user.game!!.announce(announcement, user)
           }
           return
         }
       } else if (message.message == "/help") {
-        clientHandler.user.game!!.announce(
+        game.announce(
           "/me <message> to make personal message eg. /me is bored ...SupraFast is bored.",
           clientHandler.user
         )
         threadSleep(20.milliseconds)
-        clientHandler.user.game!!.announce(
+        game.announce(
           "/msg <UserID> <msg> to PM somebody. /msgoff or /msgon to turn pm off | on.",
           clientHandler.user
         )
         threadSleep(20.milliseconds)
-        clientHandler.user.game!!.announce(
+        game.announce(
           "/ignore <UserID> or /unignore <UserID> or /ignoreall or /unignoreall to ignore users.",
           clientHandler.user
         )
         threadSleep(20.milliseconds)
-        clientHandler.user.game!!.announce(
+        game.announce(
           "/p2pon or /p2poff this option ignores all server activity during gameplay.",
           clientHandler.user
         )
         threadSleep(20.milliseconds)
       } else if (message.message == "/stop") {
         if (lookingForGameReporter.cancelActionsForUser(clientHandler.user.id)) {
-          clientHandler.user.game!!.announce(
+          game.announce(
             EmuLang.getStringOrDefault(
               "KailleraServerImpl.CanceledPendingTweet",
               default = "Canceled pending tweet."
@@ -483,27 +451,18 @@ internal constructor(
             clientHandler.user
           )
         } else {
-          clientHandler.user.game!!.announce("No pending tweets.", clientHandler.user)
+          game.announce("No pending tweets.", clientHandler.user)
         }
       } else if (message.message == "/lagstat") {
         // Note: This was duplicated from GameOwnerCommandAction.
-        clientHandler.user.game!!.announce(
-          "Lagged frames per player by delay (small may contain false positives):"
-        )
-        clientHandler.user.game!!
-          .players
+        game.announce("Lagged frames per player by delay (small may contain false positives):")
+        game.players
           .asSequence()
           .filter { !it.inStealthMode }
-          .forEach {
-            clientHandler.user.game!!.announce("P${it.playerNumber}: ${it.summarizeLag()}")
-          }
-      } else
-        clientHandler.user.game!!.announce(
-          "Unknown Command: " + message.message,
-          clientHandler.user
-        )
+          .forEach { game.announce("P${it.playerNumber}: ${it.summarizeLag()}") }
+      } else game.announce("Unknown Command: " + message.message, clientHandler.user)
     } else {
-      clientHandler.user.game!!.announce("Denied: Flood Control", clientHandler.user)
+      game.announce("Denied: Flood Control", clientHandler.user)
     }
   }
 

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameDataAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameDataAction.kt
@@ -1,8 +1,6 @@
 package org.emulinker.kaillera.controller.v086.action
 
 import com.google.common.flogger.FluentLogger
-import javax.inject.Inject
-import javax.inject.Singleton
 import org.emulinker.kaillera.controller.messaging.MessageFormatException
 import org.emulinker.kaillera.controller.v086.V086ClientHandler
 import org.emulinker.kaillera.controller.v086.protocol.CachedGameData
@@ -10,9 +8,7 @@ import org.emulinker.kaillera.controller.v086.protocol.GameData
 import org.emulinker.kaillera.model.event.GameDataEvent
 import org.emulinker.kaillera.model.exception.GameDataException
 
-@Singleton
-class GameDataAction @Inject internal constructor() :
-  V086Action<GameData>, V086GameEventHandler<GameDataEvent> {
+object GameDataAction : V086Action<GameData>, V086GameEventHandler<GameDataEvent> {
   override val actionPerformedCount = 0
   override val handledEventCount = 0
 
@@ -59,7 +55,5 @@ class GameDataAction @Inject internal constructor() :
     }
   }
 
-  companion object {
-    private val logger = FluentLogger.forEnclosingClass()
-  }
+  private val logger = FluentLogger.forEnclosingClass()
 }

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameOwnerCommandAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameOwnerCommandAction.kt
@@ -213,7 +213,7 @@ class GameOwnerCommandAction @Inject internal constructor(private val flags: Run
     game: KailleraGameImpl,
   ) {
     if (message == "/lagstat") {
-      game.announce("Lagged frames per player:")
+      game.announce("Lagged frames per player by delay (small may contain false positives):")
       game.players
         .asSequence()
         .filter { !it.inStealthMode }

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameOwnerCommandAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameOwnerCommandAction.kt
@@ -217,7 +217,7 @@ class GameOwnerCommandAction @Inject internal constructor(private val flags: Run
     if (message == "/lagstat") {
       game.announce(
         "Total game drift over last ${flags.lagstatDuration}: " +
-          (game.totalDriftNs - game.totalDriftCache.getDelayedValue())
+          (game.totalDriftNs - (game.totalDriftCache.getDelayedValue() ?: 0))
             .nanoseconds
             .absoluteValue
             .toString(MILLISECONDS) +

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameOwnerCommandAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameOwnerCommandAction.kt
@@ -21,6 +21,7 @@ import org.emulinker.util.EmuUtil.threadSleep
 class GameOwnerCommandAction @Inject internal constructor(private val flags: RuntimeFlags) :
   V086Action<GameChat> {
   override val actionPerformedCount = 0
+
   override fun toString() = "GameOwnerCommandAction"
 
   fun isValidCommand(chat: String): Boolean {
@@ -216,16 +217,10 @@ class GameOwnerCommandAction @Inject internal constructor(private val flags: Run
       game.players
         .asSequence()
         .filter { !it.inStealthMode }
-        .forEach {
-          game.announce(
-            "P${it.playerNumber}: ${it.smallLagSpikesCausedByUser} (tiny), ${it.bigLagSpikesCausedByUser} (big)"
-          )
-        }
+        .forEach { game.announce("P${it.playerNumber}: ${it.summarizeLag()}") }
     } else if (message == "/lagreset") {
       for (player in game.players) {
-        player.timeouts = 0
-        player.smallLagSpikesCausedByUser = 0
-        player.bigLagSpikesCausedByUser = 0
+        player.resetLag()
       }
       game.announce(
         "LagStat has been reset!",

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameOwnerCommandAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameOwnerCommandAction.kt
@@ -6,6 +6,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.nanoseconds
+import kotlin.time.DurationUnit.MILLISECONDS
 import org.emulinker.config.RuntimeFlags
 import org.emulinker.kaillera.access.AccessManager
 import org.emulinker.kaillera.controller.messaging.MessageFormatException
@@ -214,9 +215,13 @@ class GameOwnerCommandAction @Inject internal constructor(private val flags: Run
     game: KailleraGameImpl,
   ) {
     if (message == "/lagstat") {
-      // Note: This was duplicated from GameOwnerCommandAction.
       game.announce(
-        "Total game drift over last ${flags.lagstatDuration}: ${(game.totalDriftNs.nanoseconds - game.totalDriftCache.getDelayedValue().nanoseconds).absoluteValue}. Breakdown by player:"
+        "Total game drift over last ${flags.lagstatDuration}: " +
+          (game.totalDriftNs - game.totalDriftCache.getDelayedValue())
+            .nanoseconds
+            .absoluteValue
+            .toString(MILLISECONDS) +
+          ". Breakdown by player:"
       )
       game.players
         .asSequence()

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameOwnerCommandAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameOwnerCommandAction.kt
@@ -216,17 +216,17 @@ class GameOwnerCommandAction @Inject internal constructor(private val flags: Run
   ) {
     if (message == "/lagstat") {
       game.announce(
+        game.players
+          .filter { !it.inStealthMode }
+          .joinToString(separator = ", ") { "P${it.playerNumber}: ${it.timeouts}" } + " lag spikes"
+      )
+      game.announce(
         "Total game drift over last ${flags.lagstatDuration}: " +
           (game.totalDriftNs - (game.totalDriftCache.getDelayedValue() ?: 0))
             .nanoseconds
             .absoluteValue
-            .toString(MILLISECONDS) +
-          ". Breakdown by player:"
+            .toString(MILLISECONDS, decimals = 0)
       )
-      game.players
-        .asSequence()
-        .filter { !it.inStealthMode }
-        .forEach { game.announce("P${it.playerNumber}: ${it.summarizeLag()}") }
     } else if (message == "/lagreset") {
       for (player in game.players) {
         player.resetLag()

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/JoinGameAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/JoinGameAction.kt
@@ -20,6 +20,7 @@ internal constructor(@param:Named("joinGameMessages") private val joinGameMessag
   V086Action<JoinGameRequest>, V086GameEventHandler<UserJoinedGameEvent> {
   override var actionPerformedCount = 0
     private set
+
   override var handledEventCount = 0
     private set
 

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/KeepAliveAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/KeepAliveAction.kt
@@ -15,8 +15,6 @@ class KeepAliveAction @Inject internal constructor() : V086Action<KeepAlive> {
   @Throws(FatalActionException::class)
   override fun performAction(message: KeepAlive, clientHandler: V086ClientHandler) {
     actionPerformedCount++
-    if (clientHandler.user == null)
-      throw FatalActionException("User does not exist: KeepAliveAction!")
     clientHandler.user.updateLastKeepAlive()
   }
 }

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/LoginAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/LoginAction.kt
@@ -18,6 +18,7 @@ class LoginAction @Inject internal constructor() :
   V086Action<UserInformation>, V086ServerEventHandler<UserJoinedEvent> {
   override var actionPerformedCount = 0
     private set
+
   override var handledEventCount = 0
     private set
 

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/LoginAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/LoginAction.kt
@@ -54,7 +54,7 @@ class LoginAction @Inject internal constructor() :
         )
       )
       val thisUser = clientHandler.user
-      if (thisUser.isEmuLinkerClient && thisUser.accessLevel >= AccessManager.ACCESS_SUPERADMIN) {
+      if (thisUser.isEsfAdminClient && thisUser.accessLevel >= AccessManager.ACCESS_SUPERADMIN) {
         if (user != thisUser) {
           val sb = StringBuilder()
           sb.append(":USERINFO=")

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/QuitAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/QuitAction.kt
@@ -15,6 +15,7 @@ class QuitAction @Inject internal constructor() :
   V086Action<QuitRequest>, V086ServerEventHandler<UserQuitEvent> {
   override var actionPerformedCount = 0
     private set
+
   override var handledEventCount = 0
     private set
 

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/QuitGameAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/QuitGameAction.kt
@@ -20,6 +20,7 @@ class QuitGameAction @Inject constructor(private val lookingForGameReporter: Twi
   V086Action<QuitGameRequest>, V086GameEventHandler<UserQuitGameEvent> {
   override var actionPerformedCount = 0
     private set
+
   override var handledEventCount = 0
     private set
 

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/StartGameAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/StartGameAction.kt
@@ -19,6 +19,7 @@ internal constructor(private val lookingForGameReporter: TwitterBroadcaster) :
   V086Action<StartGameRequest>, V086GameEventHandler<GameStartedEvent> {
   override var actionPerformedCount = 0
     private set
+
   override var handledEventCount = 0
     private set
 

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/UserReadyAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/UserReadyAction.kt
@@ -14,6 +14,7 @@ class UserReadyAction @Inject internal constructor() :
   V086Action<AllReady>, V086GameEventHandler<GameEvent> {
   override var actionPerformedCount = 0
     private set
+
   override var handledEventCount = 0
     private set
 

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/V086Action.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/V086Action.kt
@@ -9,5 +9,6 @@ interface V086Action<T : V086Message> {
 
   @Throws(FatalActionException::class)
   fun performAction(message: T, clientHandler: V086ClientHandler)
+
   val actionPerformedCount: Int
 }

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/V086GameEventHandler.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/V086GameEventHandler.kt
@@ -8,5 +8,6 @@ interface V086GameEventHandler<in T : GameEvent?> {
   override fun toString(): String
 
   fun handleEvent(event: T, clientHandler: V086ClientHandler)
+
   val handledEventCount: Int
 }

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/V086ServerEventHandler.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/V086ServerEventHandler.kt
@@ -8,5 +8,6 @@ interface V086ServerEventHandler<in T : ServerEvent> {
   override fun toString(): String
 
   fun handleEvent(event: T, clientHandler: V086ClientHandler)
+
   val handledEventCount: Int
 }

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/V086UserEventHandler.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/V086UserEventHandler.kt
@@ -8,5 +8,6 @@ interface V086UserEventHandler<in T : UserEvent?> {
   override fun toString(): String
 
   fun handleEvent(event: T, clientHandler: V086ClientHandler)
+
   val handledEventCount: Int
 }

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/protocol/Chat.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/protocol/Chat.kt
@@ -33,6 +33,7 @@ sealed class Chat : V086Message() {
 
   object ChatSerializer : MessageSerializer<Chat> {
     override val messageTypeId: Byte = ID
+
     override fun read(packet: ByteReadPacket, messageNumber: Int): Result<Chat> {
       if (packet.remaining < 3) {
         return parseFailure("Failed byte count validation!")

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/protocol/CreateGame.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/protocol/CreateGame.kt
@@ -25,6 +25,7 @@ sealed class CreateGame : V086Message() {
 
   object CreateGameSerializer : MessageSerializer<CreateGame> {
     override val messageTypeId: Byte = ID
+
     override fun read(packet: ByteReadPacket, messageNumber: Int): Result<CreateGame> {
       if (packet.remaining < 8) {
         return parseFailure("Failed byte count validation!")

--- a/emulinker/src/main/java/org/emulinker/kaillera/master/client/EmuLinkerMasterUpdateTask.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/master/client/EmuLinkerMasterUpdateTask.kt
@@ -31,9 +31,9 @@ constructor(
       this.append("location", publicInfo.location)
       this.append("website", publicInfo.website)
       this.append("port", flags.serverPort.toString())
-      this.append("numUsers", kailleraServer.users.size.toString())
+      this.append("numUsers", kailleraServer.usersMap.values.size.toString())
       this.append("maxUsers", flags.maxUsers.toString())
-      this.append("numGames", kailleraServer.games.size.toString())
+      this.append("numGames", kailleraServer.gamesMap.values.size.toString())
       this.append("maxGames", flags.maxGames.toString())
       // The list only supports max 8 character versions.
       this.append("version", releaseInfo.versionWithElkPrefix.take(8))
@@ -43,7 +43,7 @@ constructor(
     connection.setRequestMethod("GET")
     connection.setRequestProperty(
       "Waiting-games",
-      kailleraServer.games
+      kailleraServer.gamesMap.values
         .filter { it.status == GameStatus.WAITING }
         .joinToString(separator = "") {
           "${it.romName}|${it.owner.name}|${it.owner.clientType}|${it.players.size}/${it.maxUsers}|"

--- a/emulinker/src/main/java/org/emulinker/kaillera/master/client/EmuLinkerMasterUpdateTask.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/master/client/EmuLinkerMasterUpdateTask.kt
@@ -12,6 +12,7 @@ import org.emulinker.config.RuntimeFlags
 import org.emulinker.kaillera.master.PublicServerInformation
 import org.emulinker.kaillera.model.GameStatus
 import org.emulinker.kaillera.model.KailleraServer
+import org.emulinker.kaillera.release.ReleaseInfo
 
 class EmuLinkerMasterUpdateTask
 @Inject
@@ -19,6 +20,7 @@ constructor(
   private val publicInfo: PublicServerInformation,
   private val kailleraServer: KailleraServer,
   private val flags: RuntimeFlags,
+  private val releaseInfo: ReleaseInfo,
 ) : MasterListUpdateTask {
 
   override fun reportStatus() {
@@ -33,9 +35,8 @@ constructor(
       this.append("maxUsers", flags.maxUsers.toString())
       this.append("numGames", kailleraServer.games.size.toString())
       this.append("maxGames", flags.maxGames.toString())
-      // I want to use `releaseInfo.versionWithElkPrefix` here, but it's too long for the db schema
-      // field, so we just write elk (lowercase in protest :P ).
-      this.append("version", "elk")
+      // The list only supports max 8 character versions.
+      this.append("version", releaseInfo.versionWithElkPrefix.take(8))
     }
 
     val connection: HttpURLConnection = URL(url.buildString()).openConnection() as HttpURLConnection

--- a/emulinker/src/main/java/org/emulinker/kaillera/master/client/KailleraMasterUpdateTask.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/master/client/KailleraMasterUpdateTask.kt
@@ -13,6 +13,7 @@ import org.emulinker.kaillera.master.PublicServerInformation
 import org.emulinker.kaillera.master.StatsCollector
 import org.emulinker.kaillera.model.GameStatus
 import org.emulinker.kaillera.model.KailleraServer
+import org.emulinker.kaillera.release.ReleaseInfo
 
 class KailleraMasterUpdateTask
 @Inject
@@ -21,6 +22,7 @@ constructor(
   private val kailleraServer: KailleraServer,
   private val statsCollector: StatsCollector,
   private val flags: RuntimeFlags,
+  private val releaseInfo: ReleaseInfo,
 ) : MasterListUpdateTask {
 
   override fun reportStatus() {
@@ -42,9 +44,8 @@ constructor(
       this.append("port", flags.serverPort.toString())
       this.append("nbusers", kailleraServer.users.size.toString())
       this.append("maxconn", flags.maxUsers.toString())
-      // I want to use `releaseInfo.versionWithElkPrefix` here, but it's too long for the db schema
-      // field, so we just write elk (lowercase in protest :P ).
-      this.append("version", "elk")
+      // The list only supports max 8 character versions.
+      this.append("version", releaseInfo.versionWithElkPrefix.take(8))
       this.append("nbgames", kailleraServer.games.size.toString())
       this.append("location", publicInfo.location)
       // If this doesn't "look right" to the server it will silently not show up in the server

--- a/emulinker/src/main/java/org/emulinker/kaillera/master/client/KailleraMasterUpdateTask.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/master/client/KailleraMasterUpdateTask.kt
@@ -42,11 +42,11 @@ constructor(
     with(url.parameters) {
       this.append("servername", publicInfo.serverName)
       this.append("port", flags.serverPort.toString())
-      this.append("nbusers", kailleraServer.users.size.toString())
+      this.append("nbusers", kailleraServer.usersMap.values.size.toString())
       this.append("maxconn", flags.maxUsers.toString())
       // The list only supports max 8 character versions.
       this.append("version", releaseInfo.versionWithElkPrefix.take(8))
-      this.append("nbgames", kailleraServer.games.size.toString())
+      this.append("nbgames", kailleraServer.gamesMap.values.size.toString())
       this.append("location", publicInfo.location)
       // If this doesn't "look right" to the server it will silently not show up in the server
       // list.
@@ -60,7 +60,7 @@ constructor(
     connection.setRequestProperty("Kaillera-games", createdGames.toString())
     connection.setRequestProperty(
       "Kaillera-wgames",
-      kailleraServer.games
+      kailleraServer.gamesMap.values
         .filter { it.status == GameStatus.WAITING }
         .joinToString(separator = "") {
           "${it.id}|${it.romName}|${it.owner.name}|${it.owner.clientType}|${it.players.size}|"

--- a/emulinker/src/main/java/org/emulinker/kaillera/model/KailleraGame.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/model/KailleraGame.kt
@@ -4,7 +4,6 @@ import kotlin.Throws
 import org.emulinker.kaillera.model.exception.CloseGameException
 import org.emulinker.kaillera.model.exception.DropGameException
 import org.emulinker.kaillera.model.exception.GameChatException
-import org.emulinker.kaillera.model.exception.GameDataException
 import org.emulinker.kaillera.model.exception.GameKickException
 import org.emulinker.kaillera.model.exception.JoinGameException
 import org.emulinker.kaillera.model.exception.QuitGameException
@@ -48,8 +47,7 @@ interface KailleraGame {
 
   @Throws(UserReadyException::class) fun ready(user: KailleraUser?, playerNumber: Int)
 
-  @Throws(GameDataException::class)
-  fun addData(user: KailleraUser, playerNumber: Int, data: ByteArray)
+  fun addData(user: KailleraUser, playerNumber: Int, data: ByteArray): Result<Unit>
 
   @Throws(DropGameException::class) fun drop(user: KailleraUser, playerNumber: Int)
 

--- a/emulinker/src/main/java/org/emulinker/kaillera/model/KailleraServer.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/model/KailleraServer.kt
@@ -42,6 +42,7 @@ import org.emulinker.util.EmuLang
 import org.emulinker.util.EmuUtil
 import org.emulinker.util.EmuUtil.threadSleep
 import org.emulinker.util.TaskScheduler
+import org.emulinker.util.stripFromProdBinary
 
 /** Holds server-wide state. */
 @Singleton
@@ -840,18 +841,21 @@ internal constructor(
   private fun run() {
     try {
       // TODO(nue): Remove this. This is just being used for testing.
-      for (game in gamesMap.values) {
-        if (game.status == GameStatus.PLAYING) {
-          logger
-            .atInfo()
-            .log(
-              "LAGSTAT: G%d - %s - %s",
-              game.id,
-              (game.totalDriftNs - (game.totalDriftCache.getDelayedValue() ?: 0))
-                .nanoseconds
-                .absoluteValue,
-              game.players.joinToString(separator = " ") { "[${it.name} ${it.summarizeLag()}]" }
-            )
+      // New lagstat is experimental.
+      stripFromProdBinary {
+        for (game in gamesMap.values) {
+          if (game.status == GameStatus.PLAYING) {
+            logger
+              .atInfo()
+              .log(
+                "LAGSTAT: G%d - %s - %s",
+                game.id,
+                (game.totalDriftNs - (game.totalDriftCache.getDelayedValue() ?: 0))
+                  .nanoseconds
+                  .absoluteValue,
+                game.players.joinToString(separator = " ") { "[${it.name} ${it.summarizeLag()}]" }
+              )
+          }
         }
       }
 

--- a/emulinker/src/main/java/org/emulinker/kaillera/model/KailleraServer.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/model/KailleraServer.kt
@@ -441,7 +441,7 @@ internal constructor(
         .atInfo()
         .log("%s logged in successfully with %s access!", user, AccessManager.ACCESS_NAMES[access])
     } else {
-      logger.atInfo().log("%s logged in successfully", user)
+      logger.atFine().log("%s logged in successfully", user)
     }
 
     // this is fairly ugly
@@ -838,7 +838,9 @@ internal constructor(
             .log(
               "LAGSTAT: G%d - %s",
               game.id,
-              game.players.joinToString(separator = " ") { "[${it.name} ${it.summarizeLag()}]" }
+              game.players.joinToString(separator = " ") {
+                "[${it.name} ${it.summarizeLag()} ${it.summarizeLagNew()}]"
+              }
             )
         }
       }

--- a/emulinker/src/main/java/org/emulinker/kaillera/model/KailleraServer.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/model/KailleraServer.kt
@@ -847,7 +847,7 @@ internal constructor(
             .log(
               "LAGSTAT: G%d - %s - %s",
               game.id,
-              (game.totalDriftNs - game.totalDriftCache.getDelayedValue())
+              (game.totalDriftNs - (game.totalDriftCache.getDelayedValue() ?: 0))
                 .nanoseconds
                 .absoluteValue,
               game.players.joinToString(separator = " ") { "[${it.name} ${it.summarizeLag()}]" }

--- a/emulinker/src/main/java/org/emulinker/kaillera/model/KailleraServer.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/model/KailleraServer.kt
@@ -14,6 +14,7 @@ import javax.inject.Singleton
 import kotlin.Throws
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.nanoseconds
 import kotlinx.datetime.Clock
 import org.emulinker.config.RuntimeFlags
 import org.emulinker.kaillera.access.AccessManager
@@ -653,7 +654,15 @@ internal constructor(
     }
     val game: KailleraGameImpl?
     val gameID = getNextGameID()
-    game = KailleraGameImpl(gameID, romName, (user as KailleraUser?)!!, this, flags.gameBufferSize)
+    game =
+      KailleraGameImpl(
+        gameID,
+        romName,
+        (user as KailleraUser?)!!,
+        this,
+        flags.gameBufferSize,
+        flags
+      )
     gamesMap[gameID] = game
     addEvent(GameCreatedEvent(this, game))
     logger.atInfo().log("%s created: %s: %s", user, game, game.romName)
@@ -836,8 +845,11 @@ internal constructor(
           logger
             .atInfo()
             .log(
-              "LAGSTAT: G%d - %s",
+              "LAGSTAT: G%d - %s - %s",
               game.id,
+              (game.totalDriftNs - game.totalDriftCache.getDelayedValue())
+                .nanoseconds
+                .absoluteValue,
               game.players.joinToString(separator = " ") { "[${it.name} ${it.summarizeLag()}]" }
             )
         }

--- a/emulinker/src/main/java/org/emulinker/kaillera/model/KailleraServer.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/model/KailleraServer.kt
@@ -838,9 +838,7 @@ internal constructor(
             .log(
               "LAGSTAT: G%d - %s",
               game.id,
-              game.players.joinToString(separator = " ") {
-                "[${it.name} ${it.summarizeLag()} ${it.summarizeLagNew()}]"
-              }
+              game.players.joinToString(separator = " ") { "[${it.name} ${it.summarizeLag()}]" }
             )
         }
       }

--- a/emulinker/src/main/java/org/emulinker/kaillera/model/KailleraServer.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/model/KailleraServer.kt
@@ -14,6 +14,7 @@ import javax.inject.Singleton
 import kotlin.Throws
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.minutes
 import kotlinx.datetime.Clock
 import org.emulinker.config.RuntimeFlags
 import org.emulinker.kaillera.access.AccessManager
@@ -105,8 +106,8 @@ internal constructor(
   fun start() {
     timerTask =
       taskScheduler.scheduleRepeating(
-        period = flags.maxPing * 3,
-        initialDelay = flags.maxPing * 3,
+        period = 1.minutes,
+        initialDelay = 1.minutes,
       ) {
         run()
       }
@@ -816,6 +817,19 @@ internal constructor(
 
   private fun run() {
     try {
+      // TODO(nue): Remove this. This is just being used for testing.
+      for (game in games) {
+        if (game.status == GameStatus.PLAYING) {
+          logger
+            .atInfo()
+            .log(
+              "LAGSTAT: G%d - %s",
+              game.id,
+              game.players.joinToString(separator = " ") { "[${it.name} ${it.summarizeLag()}]" }
+            )
+        }
+      }
+
       if (usersMap.isEmpty()) return
       for (user in users) {
         val access = accessManager.getAccess(user.connectSocketAddress.address)
@@ -823,13 +837,10 @@ internal constructor(
 
         // LagStat
         if (user.loggedIn) {
-          if (
-            user.game != null &&
-              user.game!!.status == GameStatus.PLAYING &&
-              !user.game!!.startTimeout
-          ) {
-            if (System.currentTimeMillis() - user.game!!.startTimeoutTime > 15000) {
-              user.game!!.startTimeout = true
+          val game = user.game
+          if (game != null && game.status == GameStatus.PLAYING && !game.startTimeout) {
+            if (System.currentTimeMillis() - game.startTimeoutTime > 15000) {
+              game.startTimeout = true
             }
           }
         }

--- a/emulinker/src/main/java/org/emulinker/kaillera/model/KailleraServer.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/model/KailleraServer.kt
@@ -446,7 +446,7 @@ internal constructor(
     }
 
     // this is fairly ugly
-    if (user.isEmuLinkerClient) {
+    if (user.isEsfAdminClient) {
       user.queueEvent(InfoMessageEvent(user, ":ACCESS=" + user.accessStr))
       if (access >= AccessManager.ACCESS_SUPERADMIN) {
         var sb = StringBuilder()

--- a/emulinker/src/main/java/org/emulinker/kaillera/model/KailleraUser.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/model/KailleraUser.kt
@@ -305,7 +305,7 @@ class KailleraUser(
 
   fun summarizeLag(): String =
     "drift caused: " +
-      (totalDriftNs - totalDriftCache.getDelayedValue())
+      (totalDriftNs - (totalDriftCache.getDelayedValue() ?: 0))
         .nanoseconds
         .absoluteValue
         .toString(MILLISECONDS)

--- a/emulinker/src/main/java/org/emulinker/kaillera/model/KailleraUser.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/model/KailleraUser.kt
@@ -47,8 +47,8 @@ class KailleraUser(
   var clientType: String? = null
     set(clientType) {
       field = clientType
-      if (clientType != null && clientType.startsWith(EMULINKER_CLIENT_NAME))
-        isEmuLinkerClient = true
+      if (clientType != null && clientType.startsWith(EMULINKERSF_ADMIN_CLIENT_NAME))
+        isEsfAdminClient = true
     }
 
   private val initTime = clock.now()
@@ -59,13 +59,15 @@ class KailleraUser(
   var ping = 0
   var socketAddress: InetSocketAddress? = null
   var status = UserStatus.PLAYING // TODO(nue): This probably shouldn't have a default value..
+
   /**
    * Level of access that the user has.
    *
-   * See AdminCommandAction for available values. This should be turned into an enum.
+   * See [AccessManager] for available values. This should be turned into an enum.
    */
   var accessLevel = 0
-  var isEmuLinkerClient = false
+
+  var isEsfAdminClient = false
     private set
 
   /** This marks the last time the user interacted in the server. */
@@ -567,6 +569,6 @@ class KailleraUser(
   companion object {
     private val logger = FluentLogger.forEnclosingClass()
 
-    private const val EMULINKER_CLIENT_NAME = "EmuLinker-K Admin Client"
+    private const val EMULINKERSF_ADMIN_CLIENT_NAME = "EmulinkerSF Admin Client"
   }
 }

--- a/emulinker/src/main/java/org/emulinker/kaillera/model/KailleraUser.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/model/KailleraUser.kt
@@ -11,6 +11,7 @@ import kotlin.Throws
 import kotlin.system.measureNanoTime
 import kotlin.time.Duration.Companion.nanoseconds
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.DurationUnit.MILLISECONDS
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import org.emulinker.config.RuntimeFlags
@@ -303,7 +304,11 @@ class KailleraUser(
   }
 
   fun summarizeLag(): String =
-    "drift caused: ${(totalDriftNs.nanoseconds - totalDriftCache.getDelayedValue().nanoseconds).absoluteValue}"
+    "drift caused: " +
+      (totalDriftNs - totalDriftCache.getDelayedValue())
+        .nanoseconds
+        .absoluteValue
+        .toString(MILLISECONDS)
 
   fun resetLag() {
     totalDriftNs = 0

--- a/emulinker/src/main/java/org/emulinker/kaillera/model/event/KailleraEventListener.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/model/event/KailleraEventListener.kt
@@ -2,5 +2,6 @@ package org.emulinker.kaillera.model.event
 
 interface KailleraEventListener {
   fun actionPerformed(event: KailleraEvent)
+
   fun stop()
 }

--- a/emulinker/src/main/java/org/emulinker/kaillera/model/exception/ClientAddressException.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/model/exception/ClientAddressException.kt
@@ -4,5 +4,6 @@ import java.lang.Exception
 
 class ClientAddressException : LoginException {
   constructor(message: String?) : super(message)
+
   constructor(message: String?, source: Exception?) : super(message, source)
 }

--- a/emulinker/src/main/java/org/emulinker/kaillera/model/exception/CloseGameException.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/model/exception/CloseGameException.kt
@@ -4,5 +4,6 @@ import java.lang.Exception
 
 class CloseGameException : ActionException {
   constructor(message: String?) : super(message)
+
   constructor(message: String?, source: Exception?) : super(message, source)
 }

--- a/emulinker/src/main/java/org/emulinker/kaillera/model/exception/ConnectionTypeException.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/model/exception/ConnectionTypeException.kt
@@ -4,5 +4,6 @@ import java.lang.Exception
 
 class ConnectionTypeException : LoginException {
   constructor(message: String?) : super(message)
+
   constructor(message: String?, source: Exception?) : super(message, source)
 }

--- a/emulinker/src/main/java/org/emulinker/kaillera/model/exception/CreateGameException.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/model/exception/CreateGameException.kt
@@ -4,5 +4,6 @@ import java.lang.Exception
 
 class CreateGameException : ActionException {
   constructor(message: String?) : super(message)
+
   constructor(message: String?, source: Exception?) : super(message, source)
 }

--- a/emulinker/src/main/java/org/emulinker/kaillera/model/exception/DropGameException.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/model/exception/DropGameException.kt
@@ -4,5 +4,6 @@ import java.lang.Exception
 
 class DropGameException : ActionException {
   constructor(message: String?) : super(message)
+
   constructor(message: String?, source: Exception?) : super(message, source)
 }

--- a/emulinker/src/main/java/org/emulinker/kaillera/model/exception/FloodException.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/model/exception/FloodException.kt
@@ -4,6 +4,8 @@ import java.lang.Exception
 
 class FloodException : ActionException {
   constructor() : super()
+
   constructor(message: String?) : super(message)
+
   constructor(message: String?, source: Exception?) : super(message, source)
 }

--- a/emulinker/src/main/java/org/emulinker/kaillera/model/exception/GameChatException.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/model/exception/GameChatException.kt
@@ -4,5 +4,6 @@ import java.lang.Exception
 
 class GameChatException : ActionException {
   constructor(message: String?) : super(message)
+
   constructor(message: String?, source: Exception?) : super(message, source)
 }

--- a/emulinker/src/main/java/org/emulinker/kaillera/model/exception/GameKickException.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/model/exception/GameKickException.kt
@@ -4,5 +4,6 @@ import java.lang.Exception
 
 class GameKickException : ActionException {
   constructor(message: String?) : super(message)
+
   constructor(message: String?, source: Exception?) : super(message, source)
 }

--- a/emulinker/src/main/java/org/emulinker/kaillera/model/exception/InvalidRequestException.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/model/exception/InvalidRequestException.kt
@@ -4,5 +4,6 @@ import java.lang.Exception
 
 class InvalidRequestException : Exception {
   constructor(message: String?) : super(message)
+
   constructor(message: String?, source: Exception?) : super(message, source)
 }

--- a/emulinker/src/main/java/org/emulinker/kaillera/model/exception/JoinGameException.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/model/exception/JoinGameException.kt
@@ -4,5 +4,6 @@ import java.lang.Exception
 
 class JoinGameException : ActionException {
   constructor(message: String?) : super(message)
+
   constructor(message: String?, source: Exception?) : super(message, source)
 }

--- a/emulinker/src/main/java/org/emulinker/kaillera/model/exception/LoginException.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/model/exception/LoginException.kt
@@ -4,5 +4,6 @@ import java.lang.Exception
 
 open class LoginException : ActionException {
   constructor(message: String?) : super(message)
+
   constructor(message: String?, source: Exception?) : super(message, source)
 }

--- a/emulinker/src/main/java/org/emulinker/kaillera/model/exception/NewConnectionException.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/model/exception/NewConnectionException.kt
@@ -4,5 +4,6 @@ import java.lang.Exception
 
 open class NewConnectionException : ActionException {
   constructor(message: String?) : super(message)
+
   constructor(message: String?, source: Exception?) : super(message, source)
 }

--- a/emulinker/src/main/java/org/emulinker/kaillera/model/exception/PingTimeException.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/model/exception/PingTimeException.kt
@@ -4,5 +4,6 @@ import java.lang.Exception
 
 class PingTimeException : LoginException {
   constructor(message: String?) : super(message)
+
   constructor(message: String?, source: Exception?) : super(message, source)
 }

--- a/emulinker/src/main/java/org/emulinker/kaillera/model/exception/QuitException.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/model/exception/QuitException.kt
@@ -4,5 +4,6 @@ import java.lang.Exception
 
 class QuitException : ActionException {
   constructor(message: String?) : super(message)
+
   constructor(message: String?, source: Exception?) : super(message, source)
 }

--- a/emulinker/src/main/java/org/emulinker/kaillera/model/exception/QuitGameException.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/model/exception/QuitGameException.kt
@@ -4,5 +4,6 @@ import java.lang.Exception
 
 class QuitGameException : ActionException {
   constructor(message: String?) : super(message)
+
   constructor(message: String?, source: Exception?) : super(message, source)
 }

--- a/emulinker/src/main/java/org/emulinker/kaillera/model/exception/ServerFullException.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/model/exception/ServerFullException.kt
@@ -4,5 +4,6 @@ import java.lang.Exception
 
 class ServerFullException : NewConnectionException {
   constructor(message: String?) : super(message)
+
   constructor(message: String?, source: Exception?) : super(message, source)
 }

--- a/emulinker/src/main/java/org/emulinker/kaillera/model/exception/UserNameException.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/model/exception/UserNameException.kt
@@ -4,5 +4,6 @@ import java.lang.Exception
 
 class UserNameException : LoginException {
   constructor(message: String?) : super(message)
+
   constructor(message: String?, source: Exception?) : super(message, source)
 }

--- a/emulinker/src/main/java/org/emulinker/kaillera/model/impl/AutoFireDetector.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/model/impl/AutoFireDetector.kt
@@ -6,8 +6,12 @@ interface AutoFireDetector {
   var sensitivity: Int
 
   fun start(numPlayers: Int)
+
   fun addPlayer(user: KailleraUser, playerNumber: Int)
+
   fun addData(playerNumber: Int, data: ByteArray, bytesPerAction: Int)
+
   fun stop(playerNumber: Int)
+
   fun stop()
 }

--- a/emulinker/src/main/java/org/emulinker/kaillera/model/impl/KailleraGameImpl.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/model/impl/KailleraGameImpl.kt
@@ -403,7 +403,7 @@ class KailleraGameImpl(
     val actionQueueBuilder: Array<PlayerActionQueue?> = arrayOfNulls(players.size)
     startTimeout = false
     highestUserFrameDelay = 1
-    if (server.users.size > 60) {
+    if (server.usersMap.values.size > 60) {
       ignoringUnnecessaryServerActivity = true
     }
     for (i in players.indices) {

--- a/emulinker/src/main/java/org/emulinker/kaillera/model/impl/KailleraGameImpl.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/model/impl/KailleraGameImpl.kt
@@ -609,19 +609,21 @@ class KailleraGameImpl(
    * back to the client.
    */
   @Throws(GameDataException::class)
-  override fun addData(user: KailleraUser, playerNumber: Int, data: ByteArray) {
-    val playerActionQueueCopy = playerActionQueue ?: return
+  override fun addData(user: KailleraUser, playerNumber: Int, data: ByteArray): Result<Unit> {
+    val playerActionQueueCopy = playerActionQueue ?: return Result.success(Unit)
 
     // int bytesPerAction = (data.length / actionsPerMessage);
     var timeoutCounter = 0
     // int arraySize = (playerActionQueues.length * actionsPerMessage * user.getBytesPerAction());
     if (!isSynched) {
-      throw GameDataException(
-        EmuLang.getString("KailleraGameImpl.DesynchedWarning"),
-        data,
-        actionsPerMessage,
-        playerNumber,
-        playerActionQueueCopy.size,
+      return Result.failure(
+        GameDataException(
+          EmuLang.getString("KailleraGameImpl.DesynchedWarning"),
+          data,
+          actionsPerMessage,
+          playerNumber,
+          playerActionQueueCopy.size,
+        )
       )
     }
     playerActionQueueCopy[playerNumber - 1].addActions(data)
@@ -663,17 +665,20 @@ class KailleraGameImpl(
           }
         }
         if (!isSynched) {
-          throw GameDataException(
-            EmuLang.getString("KailleraGameImpl.DesynchedWarning"),
-            data,
-            user.bytesPerAction,
-            playerNumber,
-            playerActionQueueCopy.size,
+          return Result.failure(
+            GameDataException(
+              EmuLang.getString("KailleraGameImpl.DesynchedWarning"),
+              data,
+              user.bytesPerAction,
+              playerNumber,
+              playerActionQueueCopy.size,
+            )
           )
         }
         player.queueEvent(GameDataEvent(this, response))
       }
     }
+    return Result.success(Unit)
   }
 
   // it's very important this method is synchronized

--- a/emulinker/src/main/java/org/emulinker/kaillera/model/impl/KailleraGameImpl.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/model/impl/KailleraGameImpl.kt
@@ -66,8 +66,10 @@ class KailleraGameImpl(
 
   override val players: MutableList<KailleraUser> = CopyOnWriteArrayList()
 
+  var lagLeewayNs = 0.seconds.inWholeNanoseconds
   var totalDriftNs = 0.seconds.inWholeNanoseconds
   val totalDriftCache = TimeOffsetCache(delay = flags.lagstatDuration, resolution = 5.seconds)
+
   /** The user ID that will be measuring game drift. */
   var driftSetterId: Int? = null
     private set

--- a/emulinker/src/main/java/org/emulinker/kaillera/model/impl/KailleraGameImpl.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/model/impl/KailleraGameImpl.kt
@@ -410,7 +410,6 @@ class KailleraGameImpl(
       val player = players[i]
       val playerNumber = i + 1
       if (!swap) player.playerNumber = playerNumber
-      player.timeouts = 0
       player.frameCount = 0
       actionQueueBuilder[i] =
         PlayerActionQueue(
@@ -687,7 +686,6 @@ class KailleraGameImpl(
     playerActionQueue.lastTimeout = e
     val player: KailleraUser = e.player!!
     if (timeoutNumber < desynchTimeouts) {
-      if (startTimeout) player.timeouts = player.timeouts + 1
       if (timeoutNumber % 12 == 0) {
         logger.atInfo().log("%s: %s: Timeout #%d", this, player, timeoutNumber / 12)
         addEventForAllPlayers(GameTimeoutEvent(this, player, timeoutNumber / 12))

--- a/emulinker/src/main/java/org/emulinker/kaillera/model/impl/Trivia.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/model/impl/Trivia.kt
@@ -23,6 +23,7 @@ class Trivia(private val server: KailleraServer) : Runnable {
   private var hint2 = false
   var isAnswered = false
     private set
+
   private var questionsCount = 0
   private var ipStreak = ""
   private var scoreStreak = 0
@@ -30,6 +31,7 @@ class Trivia(private val server: KailleraServer) : Runnable {
   private val questions: MutableList<Questions> = ArrayList()
   private val questionsNum: MutableList<Int> = ArrayList()
   private val scores: MutableList<Scores> = ArrayList()
+
   fun setQuestionTime(questionTime: Int) {
     this.questionTime = questionTime
   }
@@ -43,6 +45,7 @@ class Trivia(private val server: KailleraServer) : Runnable {
   }
 
   inner class Scores(var nick: String, var iP: String, var score: Int)
+
   private inner class Questions(var question: String, var answer: String)
 
   override fun run() {

--- a/emulinker/src/main/java/org/emulinker/kaillera/pico/AppComponent.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/pico/AppComponent.kt
@@ -3,6 +3,7 @@ package org.emulinker.kaillera.pico
 import com.codahale.metrics.MetricRegistry
 import dagger.Component
 import javax.inject.Singleton
+import kotlinx.datetime.Clock
 import org.apache.commons.configuration.Configuration
 import org.emulinker.config.RuntimeFlags
 import org.emulinker.kaillera.access.AccessManager2
@@ -24,4 +25,5 @@ abstract class AppComponent {
   abstract val masterListUpdater: MasterListUpdater
   abstract val metricRegistry: MetricRegistry
   abstract val flags: RuntimeFlags
+  abstract val clock: Clock
 }

--- a/emulinker/src/main/java/org/emulinker/kaillera/pico/ServerMain.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/pico/ServerMain.kt
@@ -6,10 +6,8 @@ import com.codahale.metrics.MetricFilter
 import com.codahale.metrics.jvm.ThreadStatesGaugeSet
 import com.google.common.flogger.FluentLogger
 import java.io.File
-import java.time.Instant
-import java.time.ZoneId
-import java.time.format.DateTimeFormatter
 import java.util.concurrent.TimeUnit.*
+import org.emulinker.util.EmuUtil.toSimpleUtcDatetime
 import org.emulinker.util.stripFromProdBinary
 
 private val logger = FluentLogger.forEnclosingClass()
@@ -47,10 +45,7 @@ fun main() {
   }
   logger
     .atInfo()
-    .log(
-      "EmuLinker server is running @ %s",
-      DateTimeFormatter.ISO_ZONED_DATE_TIME.withZone(ZoneId.systemDefault()).format(Instant.now())
-    )
+    .log("EmuLinker server is running @ %s", component.clock.now().toSimpleUtcDatetime())
   // Essentially does nothing.
   component.kailleraServerController.start()
 

--- a/emulinker/src/main/java/org/emulinker/kaillera/release/ReleaseInfo.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/release/ReleaseInfo.kt
@@ -1,13 +1,13 @@
 package org.emulinker.kaillera.release
 
-import java.time.Instant
 import javax.inject.Inject
+import kotlinx.datetime.Instant
 import org.emulinker.kaillera.pico.CompiledFlags
 import org.emulinker.kaillera.pico.CompiledFlags.BUILD_DATE
 import org.emulinker.kaillera.pico.CompiledFlags.PROJECT_NAME
 import org.emulinker.kaillera.pico.CompiledFlags.PROJECT_URL
 import org.emulinker.kaillera.pico.CompiledFlags.PROJECT_VERSION
-import org.emulinker.util.EmuUtil
+import org.emulinker.util.EmuUtil.toSimpleUtcDatetime
 
 /**
  * Provides release and build information for the EmuLinker project. This class also formats a
@@ -32,7 +32,7 @@ class ReleaseInfo @Inject constructor() {
    * server startup.
    */
   val welcome =
-    """// $productName version $version (${EmuUtil.toSimpleUtcDatetime(buildDate)}) 
+    """// $productName version $version (${buildDate.toSimpleUtcDatetime()}) 
 // $licenseInfo
 // For the most up-to-date information please visit: $websiteString"""
 }

--- a/emulinker/src/main/java/org/emulinker/net/UDPRelay.kt
+++ b/emulinker/src/main/java/org/emulinker/net/UDPRelay.kt
@@ -22,7 +22,9 @@ abstract class UDPRelay(
 ) : Runnable {
   var listenChannel: DatagramChannel? = null
     protected set
+
   protected var clients = Collections.synchronizedMap(HashMap<InetSocketAddress, ClientHandler>())
+
   protected abstract fun processClientToServer(
     receiveBuffer: ByteBuffer,
     fromAddress: InetSocketAddress,
@@ -76,6 +78,7 @@ abstract class UDPRelay(
   protected inner class ClientHandler(protected var clientSocketAddress: InetSocketAddress) :
     Runnable {
     protected var clientChannel: DatagramChannel
+
     @Throws(Exception::class)
     fun send(buffer: ByteBuffer) {
       //			logger.atInfo().log(EmuUtil.formatSocketAddress(clientSocketAddress) + " -> \t" +

--- a/emulinker/src/main/java/org/emulinker/net/UDPRelay2.kt
+++ b/emulinker/src/main/java/org/emulinker/net/UDPRelay2.kt
@@ -21,11 +21,14 @@ constructor(
 ) {
   var isStarted = false
     protected set
+
   protected var stopFlag = false
   var exception: Exception? = null
     protected set
+
   protected var relayThreads = Hashtable<InetSocketAddress, RelayThread>()
   protected var channels = Hashtable<Int, DatagramChannel?>()
+
   protected abstract fun processClientToServer(
     receiveBuffer: ByteBuffer?,
     fromAddress: InetSocketAddress?,
@@ -70,6 +73,7 @@ constructor(
     protected var port = 0
     var channel: DatagramChannel? = null
       protected set
+
     var forwardAddress: InetSocketAddress?
       protected set
 
@@ -77,6 +81,7 @@ constructor(
 
     var lastActivity: Long
       protected set
+
     protected var running = false
 
     protected constructor(forwardAddress: InetSocketAddress?) : this(-1, forwardAddress) {}

--- a/emulinker/src/main/java/org/emulinker/util/EmuUtil.kt
+++ b/emulinker/src/main/java/org/emulinker/util/EmuUtil.kt
@@ -10,11 +10,14 @@ import java.nio.ByteBuffer
 import java.nio.charset.Charset
 import java.text.DateFormat
 import java.text.SimpleDateFormat
-import java.time.Instant
-import java.time.ZoneOffset
-import java.time.format.DateTimeFormatter
 import java.util.Properties
 import kotlin.time.Duration
+import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.format
+import kotlinx.datetime.format.DateTimeComponents
+import kotlinx.datetime.format.format
+import kotlinx.datetime.offsetIn
 import org.emulinker.kaillera.pico.AppModule
 
 object EmuUtil {
@@ -285,8 +288,13 @@ object EmuUtil {
     }
   }
 
-  fun toSimpleUtcDatetime(instant: Instant): String =
-    DateTimeFormatter.RFC_1123_DATE_TIME.withZone(ZoneOffset.UTC).format(instant)
+  fun Instant.toSimpleUtcDatetime(): String =
+    DateTimeComponents.Formats.RFC_1123.format {
+      setDateTimeOffset(
+        this@toSimpleUtcDatetime,
+        this@toSimpleUtcDatetime.offsetIn(TimeZone.currentSystemDefault())
+      )
+    }
 
   // TODO(nue): Get rid of this after it's confirmed it can be safely removed.
   /** NOOP placeholder for a function that _used to_ call [Thread.sleep]. */

--- a/emulinker/src/main/java/org/emulinker/util/GameDataCache.kt
+++ b/emulinker/src/main/java/org/emulinker/util/GameDataCache.kt
@@ -2,10 +2,14 @@ package org.emulinker.util
 
 interface GameDataCache : Collection<ByteArray?> {
   operator fun get(index: Int): ByteArray?
+
   operator fun set(index: Int, data: ByteArray?): ByteArray?
 
   fun add(data: ByteArray?): Int
+
   fun indexOf(data: ByteArray?): Int
+
   fun clear()
+
   fun remove(index: Int): ByteArray?
 }

--- a/emulinker/src/main/java/org/emulinker/util/GameDataQueue.kt
+++ b/emulinker/src/main/java/org/emulinker/util/GameDataQueue.kt
@@ -86,6 +86,7 @@ class GameDataQueue(
 
   class PlayerTimeoutException(val playerNumber: Int, val timeoutNumber: Int, e: TimeoutException) :
     Exception(e)
+
   class DesynchException(msg: String, val playerNumber: Int, e: TimeoutException) :
     Exception(msg, e)
 }

--- a/emulinker/src/main/java/org/emulinker/util/TimeOffsetCache.kt
+++ b/emulinker/src/main/java/org/emulinker/util/TimeOffsetCache.kt
@@ -27,14 +27,18 @@ class TimeOffsetCache(delay: Duration, resolution: Duration) {
   }
 
   @Synchronized
-  fun getDelayedValue(): Long {
-    check(size != 0) { "No data" }
-
-    if (size < cacheSize) {
-      return cache[0]!!
+  fun getDelayedValue(): Long? =
+    when {
+      size == 0 -> {
+        null
+      }
+      size < cacheSize -> {
+        cache[0]!!
+      }
+      else -> {
+        cache[(last + 1) % cacheSize]!!
+      }
     }
-    return cache[(last + 1) % cacheSize]!!
-  }
 
   @Synchronized
   fun clear() {

--- a/emulinker/src/main/java/org/emulinker/util/UnsignedUtil.kt
+++ b/emulinker/src/main/java/org/emulinker/util/UnsignedUtil.kt
@@ -34,6 +34,7 @@ object UnsignedUtil {
   fun ByteBuf.getUnsignedShort(): Int = this.readShort().toInt() and 0xffff
 
   fun ByteReadPacket.readUnsignedShort(): Int = this.readShort().toInt() and 0xffff
+
   fun ByteReadPacket.readUnsignedShortLittleEndian(): Int =
     this.readShortLittleEndian().toInt() and 0xffff
 

--- a/emulinker/src/test/java/org/emulinker/util/TimeOffsetCacheTest.kt
+++ b/emulinker/src/test/java/org/emulinker/util/TimeOffsetCacheTest.kt
@@ -1,0 +1,37 @@
+package org.emulinker.util
+
+import com.google.common.truth.Truth.assertThat
+import kotlin.time.Duration.Companion.nanoseconds
+import org.junit.Test
+
+class TimeOffsetCacheTest {
+
+  @Test
+  fun `cache and retrieve single value`() {
+    val target = TimeOffsetCache(delay = 100.nanoseconds, resolution = 10.nanoseconds)
+
+    target.update(latestVal = 42, nowNs = 0)
+
+    assertThat(target.getDelayedValue()).isEqualTo(42)
+  }
+
+  @Test
+  fun `update should ignore new values within resolution`() {
+    val target = TimeOffsetCache(delay = 100.nanoseconds, resolution = 10.nanoseconds)
+
+    target.update(latestVal = 42, nowNs = 0)
+    target.update(latestVal = 100, nowNs = 9)
+
+    assertThat(target.getDelayedValue()).isEqualTo(42)
+  }
+
+  @Test
+  fun `retrieve from full cache`() {
+    val target = TimeOffsetCache(delay = 30.nanoseconds, resolution = 10.nanoseconds)
+
+    repeat(100) { target.update(latestVal = it.toLong(), nowNs = 10L * it) }
+
+    // The last values we put were 99, 98, 97.
+    assertThat(target.getDelayedValue()).isEqualTo(97)
+  }
+}


### PR DESCRIPTION
- Bump dependencies (including formatter).
- Only check into main server every 30m.
- Only run KailleraServer.run() every minute (we will need to make sure this is not the only method of enforcing bans etc.)
- Fix lagstat for higher than 1f users.
- Adjust lag thresholds

Importantly this uses Kotlin V2 with the K2 compiler.