### PR TITLE
Fix NPE when user is joining or creating game in an invalid state

### DIFF
--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/ACKAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/ACKAction.kt
@@ -15,17 +15,10 @@ import org.emulinker.kaillera.model.exception.*
 import org.emulinker.util.EmuUtil.threadSleep
 
 class ACKAction : V086Action<ClientAck>, V086UserEventHandler<UserEvent> {
-  override var actionPerformedCount = 0
-    private set
-
-  override var handledEventCount = 0
-    private set
-
   override fun toString() = "ACKAction"
 
   @Throws(FatalActionException::class)
   override fun performAction(message: ClientAck, clientHandler: V086ClientHandler) {
-    actionPerformedCount++
     val user = clientHandler.user
     if (user.loggedIn) {
       return
@@ -73,7 +66,6 @@ class ACKAction : V086Action<ClientAck>, V086UserEventHandler<UserEvent> {
   }
 
   override fun handleEvent(event: UserEvent, clientHandler: V086ClientHandler) {
-    handledEventCount++
     val connectedEvent = event as ConnectedEvent
     val server = connectedEvent.server
     val thisUser = connectedEvent.user

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/AdminCommandAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/AdminCommandAction.kt
@@ -22,8 +22,6 @@ import org.emulinker.util.EmuUtil.toSimpleUtcDatetime
 import org.emulinker.util.WildcardStringPattern
 
 class AdminCommandAction : V086Action<Chat> {
-  override val actionPerformedCount = 0
-
   override fun toString() = "AdminCommandAction"
 
   fun isValidCommand(chat: String): Boolean {

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/CachedGameDataAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/CachedGameDataAction.kt
@@ -11,8 +11,6 @@ import org.emulinker.kaillera.controller.v086.protocol.GameData.Companion.create
 import org.emulinker.kaillera.model.exception.GameDataException
 
 object CachedGameDataAction : V086Action<CachedGameData> {
-  override val actionPerformedCount = 0
-
   override fun toString() = "CachedGameDataAction"
 
   @Throws(FatalActionException::class)

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/ChatAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/ChatAction.kt
@@ -19,12 +19,6 @@ private const val ADMIN_COMMAND_ESCAPE_STRING = "/"
 
 class ChatAction(private val adminCommandAction: AdminCommandAction) :
   V086Action<ChatRequest>, V086ServerEventHandler<ChatEvent> {
-  override var actionPerformedCount = 0
-    private set
-
-  override var handledEventCount = 0
-    private set
-
   override fun toString() = "ChatAction"
 
   @Throws(FatalActionException::class)
@@ -48,7 +42,6 @@ class ChatAction(private val adminCommandAction: AdminCommandAction) :
       checkCommands(message, clientHandler)
       return
     }
-    actionPerformedCount++
     try {
       clientHandler.user.chat(message.message)
     } catch (e: ActionException) {
@@ -699,7 +692,6 @@ class ChatAction(private val adminCommandAction: AdminCommandAction) :
   }
 
   override fun handleEvent(event: ChatEvent, clientHandler: V086ClientHandler) {
-    handledEventCount++
     try {
       if (
         clientHandler.user.searchIgnoredUsers(event.user.connectSocketAddress.address.hostAddress)

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/CloseGameAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/CloseGameAction.kt
@@ -7,13 +7,9 @@ import org.emulinker.kaillera.controller.v086.protocol.CloseGame
 import org.emulinker.kaillera.model.event.GameClosedEvent
 
 class CloseGameAction : V086ServerEventHandler<GameClosedEvent> {
-  override var handledEventCount = 0
-    private set
-
   override fun toString() = "CloseGameAction"
 
   override fun handleEvent(event: GameClosedEvent, clientHandler: V086ClientHandler) {
-    handledEventCount++
     try {
       clientHandler.send(CloseGame(clientHandler.nextMessageNumber, event.game.id, 0))
     } catch (e: MessageFormatException) {

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/CreateGameAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/CreateGameAction.kt
@@ -20,17 +20,10 @@ class CreateGameAction :
   V086Action<CreateGame>, V086ServerEventHandler<GameCreatedEvent>, KoinComponent {
   private val joinGameMessages: List<String> by inject(named("joinGameMessages"))
 
-  override var actionPerformedCount = 0
-    private set
-
-  override var handledEventCount = 0
-    private set
-
   override fun toString() = "CreateGameAction"
 
   @Throws(FatalActionException::class)
   override fun performAction(message: CreateGame, clientHandler: V086ClientHandler) {
-    actionPerformedCount++
     try {
       val game = clientHandler.user.createGame(message.romName)
 
@@ -52,10 +45,12 @@ class CreateGameAction :
             EmuLang.getString("CreateGameAction.CreateGameDenied", e.message),
           )
         )
+        // TODO(nue): If clientHandler.user.name == null (meaning the user is not logged in) do we
+        // need to send this?
         clientHandler.send(
           QuitGameNotification(
             clientHandler.nextMessageNumber,
-            clientHandler.user.name!!,
+            clientHandler.user.name ?: "",
             clientHandler.user.id,
           )
         )
@@ -75,10 +70,12 @@ class CreateGameAction :
             EmuLang.getString("CreateGameAction.CreateGameDeniedFloodControl"),
           )
         )
+        // TODO(nue): If clientHandler.user.name == null (meaning the user is not logged in) do we
+        // need to send this?
         clientHandler.send(
           QuitGameNotification(
             clientHandler.nextMessageNumber,
-            clientHandler.user.name!!,
+            clientHandler.user.name ?: "",
             clientHandler.user.id,
           )
         )
@@ -89,7 +86,6 @@ class CreateGameAction :
   }
 
   override fun handleEvent(event: GameCreatedEvent, clientHandler: V086ClientHandler) {
-    handledEventCount++
     try {
       val game = event.game
       val owner = game.owner

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/DropGameAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/DropGameAction.kt
@@ -9,17 +9,10 @@ import org.emulinker.kaillera.model.event.UserDroppedGameEvent
 import org.emulinker.kaillera.model.exception.DropGameException
 
 class DropGameAction : V086Action<PlayerDropRequest>, V086GameEventHandler<UserDroppedGameEvent> {
-  override var actionPerformedCount = 0
-    private set
-
-  override var handledEventCount = 0
-    private set
-
   override fun toString() = "DropGameAction"
 
   @Throws(FatalActionException::class)
   override fun performAction(message: PlayerDropRequest, clientHandler: V086ClientHandler) {
-    actionPerformedCount++
     try {
       clientHandler.user.dropGame()
     } catch (e: DropGameException) {
@@ -28,7 +21,6 @@ class DropGameAction : V086Action<PlayerDropRequest>, V086GameEventHandler<UserD
   }
 
   override fun handleEvent(event: UserDroppedGameEvent, clientHandler: V086ClientHandler) {
-    handledEventCount++
     try {
       val user = event.user
       val playerNumber = event.playerNumber

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameChatAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameChatAction.kt
@@ -36,12 +36,6 @@ class GameChatAction(
   private val flags: RuntimeFlags,
   private val clock: Clock,
 ) : V086Action<GameChatRequest>, V086GameEventHandler<GameChatEvent> {
-  override var actionPerformedCount = 0
-    private set
-
-  override var handledEventCount = 0
-    private set
-
   override fun toString() = "GameChatAction"
 
   @Throws(FatalActionException::class)
@@ -60,7 +54,6 @@ class GameChatAction(
         logger.atWarning().withCause(e).log("GameOwner command failed")
       }
     }
-    actionPerformedCount++
     try {
       clientHandler.user.gameChat(message.message, message.messageNumber)
     } catch (e: GameChatException) {
@@ -567,7 +560,6 @@ class GameChatAction(
   }
 
   override fun handleEvent(gameChatEvent: GameChatEvent, clientHandler: V086ClientHandler) {
-    handledEventCount++
     try {
       if (
         clientHandler.user.searchIgnoredUsers(

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameDataAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameDataAction.kt
@@ -10,9 +10,6 @@ import org.emulinker.kaillera.model.event.GameDataEvent
 import org.emulinker.kaillera.model.exception.GameDataException
 
 object GameDataAction : V086Action<GameData>, V086GameEventHandler<GameDataEvent> {
-  override val actionPerformedCount = 0
-  override val handledEventCount = 0
-
   override fun toString() = "GameDataAction"
 
   @Throws(FatalActionException::class)

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameDesynchAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameDesynchAction.kt
@@ -8,13 +8,9 @@ import org.emulinker.kaillera.model.event.GameDesynchEvent
 import org.emulinker.util.EmuLang
 
 class GameDesynchAction : V086GameEventHandler<GameDesynchEvent> {
-  override var handledEventCount = 0
-    private set
-
   override fun toString() = "GameDesynchAction"
 
   override fun handleEvent(event: GameDesynchEvent, clientHandler: V086ClientHandler) {
-    handledEventCount++
     try {
       clientHandler.send(
         GameChatNotification(

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameInfoAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameInfoAction.kt
@@ -7,13 +7,9 @@ import org.emulinker.kaillera.controller.v086.protocol.GameChatNotification
 import org.emulinker.kaillera.model.event.GameInfoEvent
 
 class GameInfoAction : V086GameEventHandler<GameInfoEvent> {
-  override var handledEventCount = 0
-    private set
-
   override fun toString() = "GameInfoAction"
 
   override fun handleEvent(event: GameInfoEvent, clientHandler: V086ClientHandler) {
-    handledEventCount++
     if (event.toUser != null) {
       if (event.toUser !== clientHandler.user) return
     }

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameKickAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameKickAction.kt
@@ -8,14 +8,10 @@ import org.emulinker.kaillera.controller.v086.protocol.GameKick
 import org.emulinker.kaillera.model.exception.GameKickException
 
 class GameKickAction : V086Action<GameKick> {
-  override var actionPerformedCount = 0
-    private set
-
   override fun toString() = "GameKickAction"
 
   @Throws(FatalActionException::class)
   override fun performAction(message: GameKick, clientHandler: V086ClientHandler) {
-    actionPerformedCount++
     try {
       clientHandler.user.gameKick(message.userId)
     } catch (e: GameKickException) {

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameOwnerCommandAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameOwnerCommandAction.kt
@@ -15,8 +15,6 @@ import org.emulinker.util.EmuLang
 import org.emulinker.util.EmuUtil.threadSleep
 
 class GameOwnerCommandAction : V086Action<GameChat> {
-  override val actionPerformedCount = 0
-
   override fun toString() = "GameOwnerCommandAction"
 
   fun isValidCommand(chat: String): Boolean =

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameStatusAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameStatusAction.kt
@@ -7,13 +7,9 @@ import org.emulinker.kaillera.controller.v086.protocol.GameStatus
 import org.emulinker.kaillera.model.event.GameStatusChangedEvent
 
 class GameStatusAction : V086ServerEventHandler<GameStatusChangedEvent> {
-  override var handledEventCount = 0
-    private set
-
   override fun toString() = "GameStatusAction"
 
   override fun handleEvent(event: GameStatusChangedEvent, clientHandler: V086ClientHandler) {
-    handledEventCount++
     try {
       val game = event.game
       val visiblePlayers = game.players.count { !it.inStealthMode }

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameTimeoutAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameTimeoutAction.kt
@@ -5,13 +5,9 @@ import org.emulinker.kaillera.controller.v086.V086ClientHandler
 import org.emulinker.kaillera.model.event.GameTimeoutEvent
 
 class GameTimeoutAction : V086GameEventHandler<GameTimeoutEvent> {
-  override var handledEventCount = 0
-    private set
-
   override fun toString() = "GameTimeoutAction"
 
   override fun handleEvent(event: GameTimeoutEvent, clientHandler: V086ClientHandler) {
-    handledEventCount++
     val player = event.user
     val user = clientHandler.user
     if (player == user) {

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/InfoMessageAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/InfoMessageAction.kt
@@ -7,13 +7,9 @@ import org.emulinker.kaillera.controller.v086.protocol.InformationMessage
 import org.emulinker.kaillera.model.event.InfoMessageEvent
 
 class InfoMessageAction : V086UserEventHandler<InfoMessageEvent> {
-  override var handledEventCount = 0
-    private set
-
   override fun toString() = "InfoMessageAction"
 
   override fun handleEvent(event: InfoMessageEvent, clientHandler: V086ClientHandler) {
-    handledEventCount++
     try {
       clientHandler.send(
         InformationMessage(clientHandler.nextMessageNumber, "server", event.message)

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/JoinGameAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/JoinGameAction.kt
@@ -17,17 +17,10 @@ class JoinGameAction :
   V086Action<JoinGameRequest>, V086GameEventHandler<UserJoinedGameEvent>, KoinComponent {
   private val joinGameMessages: List<String> by inject(named("joinGameMessages"))
 
-  override var actionPerformedCount = 0
-    private set
-
-  override var handledEventCount = 0
-    private set
-
   override fun toString() = "JoinGameAction"
 
   @Throws(FatalActionException::class)
   override fun performAction(message: JoinGameRequest, clientHandler: V086ClientHandler) {
-    actionPerformedCount++
     try {
       val game = clientHandler.user.joinGame(message.gameId)
 
@@ -47,7 +40,7 @@ class JoinGameAction :
         clientHandler.send(
           QuitGameNotification(
             clientHandler.nextMessageNumber,
-            clientHandler.user.name!!,
+            clientHandler.user.name ?: "(empty username)",
             clientHandler.user.id,
           )
         )
@@ -58,7 +51,6 @@ class JoinGameAction :
   }
 
   override fun handleEvent(event: UserJoinedGameEvent, clientHandler: V086ClientHandler) {
-    handledEventCount++
     val thisUser = clientHandler.user
     try {
       val game = event.game

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/KeepAliveAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/KeepAliveAction.kt
@@ -4,14 +4,10 @@ import org.emulinker.kaillera.controller.v086.V086ClientHandler
 import org.emulinker.kaillera.controller.v086.protocol.KeepAlive
 
 class KeepAliveAction : V086Action<KeepAlive> {
-  override var actionPerformedCount = 0
-    private set
-
   override fun toString() = "KeepAliveAction"
 
   @Throws(FatalActionException::class)
   override fun performAction(message: KeepAlive, clientHandler: V086ClientHandler) {
-    actionPerformedCount++
     clientHandler.user.updateLastKeepAlive()
   }
 }

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/LoginAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/LoginAction.kt
@@ -12,17 +12,10 @@ import org.emulinker.kaillera.model.KailleraUser
 import org.emulinker.kaillera.model.event.UserJoinedEvent
 
 class LoginAction : V086Action<UserInformation>, V086ServerEventHandler<UserJoinedEvent> {
-  override var actionPerformedCount = 0
-    private set
-
-  override var handledEventCount = 0
-    private set
-
   override fun toString() = "LoginAction"
 
   @Throws(FatalActionException::class)
   override fun performAction(message: UserInformation, clientHandler: V086ClientHandler) {
-    actionPerformedCount++
     val user: KailleraUser = clientHandler.user
     user.name = message.username
     user.clientType = message.clientType
@@ -37,7 +30,6 @@ class LoginAction : V086Action<UserInformation>, V086ServerEventHandler<UserJoin
   }
 
   override fun handleEvent(event: UserJoinedEvent, clientHandler: V086ClientHandler) {
-    handledEventCount++
     try {
       val user = event.user
       clientHandler.send(

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/PlayerDesynchAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/PlayerDesynchAction.kt
@@ -8,13 +8,9 @@ import org.emulinker.kaillera.model.event.PlayerDesynchEvent
 import org.emulinker.util.EmuLang
 
 class PlayerDesynchAction : V086GameEventHandler<PlayerDesynchEvent> {
-  override var handledEventCount = 0
-    private set
-
   override fun toString(): String = PlayerDesynchAction::class.java.simpleName
 
   override fun handleEvent(event: PlayerDesynchEvent, clientHandler: V086ClientHandler) {
-    handledEventCount++
     try {
       clientHandler.send(
         GameChatNotification(

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/QuitAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/QuitAction.kt
@@ -9,17 +9,10 @@ import org.emulinker.kaillera.model.event.UserQuitEvent
 import org.emulinker.kaillera.model.exception.ActionException
 
 class QuitAction : V086Action<QuitRequest>, V086ServerEventHandler<UserQuitEvent> {
-  override var actionPerformedCount = 0
-    private set
-
-  override var handledEventCount = 0
-    private set
-
   override fun toString() = "QuitAction"
 
   @Throws(FatalActionException::class)
   override fun performAction(message: QuitRequest, clientHandler: V086ClientHandler) {
-    actionPerformedCount++
     try {
       clientHandler.user.quit(message.message)
     } catch (e: ActionException) {
@@ -28,7 +21,6 @@ class QuitAction : V086Action<QuitRequest>, V086ServerEventHandler<UserQuitEvent
   }
 
   override fun handleEvent(event: UserQuitEvent, clientHandler: V086ClientHandler) {
-    handledEventCount++
     try {
       val user = event.user
       clientHandler.send(

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/QuitGameAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/QuitGameAction.kt
@@ -15,17 +15,10 @@ import org.emulinker.util.EmuUtil.threadSleep
 
 class QuitGameAction(private val lookingForGameReporter: TwitterBroadcaster) :
   V086Action<QuitGameRequest>, V086GameEventHandler<UserQuitGameEvent> {
-  override var actionPerformedCount = 0
-    private set
-
-  override var handledEventCount = 0
-    private set
-
   override fun toString() = "QuitGameAction"
 
   @Throws(FatalActionException::class)
   override fun performAction(message: QuitGameRequest, clientHandler: V086ClientHandler) {
-    actionPerformedCount++
     try {
       clientHandler.user.quitGame()
       lookingForGameReporter.cancelActionsForUser(clientHandler.user.id)
@@ -40,7 +33,6 @@ class QuitGameAction(private val lookingForGameReporter: TwitterBroadcaster) :
   }
 
   override fun handleEvent(event: UserQuitGameEvent, clientHandler: V086ClientHandler) {
-    handledEventCount++
     val thisUser = clientHandler.user
     try {
       val user = event.user

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/StartGameAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/StartGameAction.kt
@@ -12,16 +12,9 @@ import org.emulinker.kaillera.model.exception.StartGameException
 
 class StartGameAction(private val lookingForGameReporter: TwitterBroadcaster) :
   V086Action<StartGameRequest>, V086GameEventHandler<GameStartedEvent> {
-  override var actionPerformedCount = 0
-    private set
-
-  override var handledEventCount = 0
-    private set
-
   override fun toString() = "StartGameAction"
 
   override fun performAction(message: StartGameRequest, clientHandler: V086ClientHandler) {
-    actionPerformedCount++
     try {
       clientHandler.user.startGame()
     } catch (e: StartGameException) {
@@ -37,7 +30,6 @@ class StartGameAction(private val lookingForGameReporter: TwitterBroadcaster) :
   }
 
   override fun handleEvent(event: GameStartedEvent, clientHandler: V086ClientHandler) {
-    handledEventCount++
     try {
       val game = event.game
       clientHandler.user.tempDelay = game.highestUserFrameDelay - clientHandler.user.frameDelay

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/UserReadyAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/UserReadyAction.kt
@@ -8,17 +8,10 @@ import org.emulinker.kaillera.model.event.GameEvent
 import org.emulinker.kaillera.model.exception.UserReadyException
 
 class UserReadyAction : V086Action<AllReady>, V086GameEventHandler<GameEvent> {
-  override var actionPerformedCount = 0
-    private set
-
-  override var handledEventCount = 0
-    private set
-
   override fun toString() = "UserReadyAction"
 
   @Throws(FatalActionException::class)
   override fun performAction(message: AllReady, clientHandler: V086ClientHandler) {
-    actionPerformedCount++
     try {
       clientHandler.user.playerReady()
     } catch (e: UserReadyException) {
@@ -27,7 +20,6 @@ class UserReadyAction : V086Action<AllReady>, V086GameEventHandler<GameEvent> {
   }
 
   override fun handleEvent(event: GameEvent, clientHandler: V086ClientHandler) {
-    handledEventCount++
     clientHandler.resetGameDataCache()
     try {
       clientHandler.send(AllReady(clientHandler.nextMessageNumber))

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/V086Action.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/V086Action.kt
@@ -9,6 +9,4 @@ interface V086Action<T : V086Message> {
 
   @Throws(FatalActionException::class)
   fun performAction(message: T, clientHandler: V086ClientHandler)
-
-  val actionPerformedCount: Int
 }

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/V086GameEventHandler.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/V086GameEventHandler.kt
@@ -8,6 +8,4 @@ interface V086GameEventHandler<in T : GameEvent?> {
   override fun toString(): String
 
   fun handleEvent(event: T, clientHandler: V086ClientHandler)
-
-  val handledEventCount: Int
 }

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/V086ServerEventHandler.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/V086ServerEventHandler.kt
@@ -8,6 +8,4 @@ interface V086ServerEventHandler<in T : ServerEvent> {
   override fun toString(): String
 
   fun handleEvent(event: T, clientHandler: V086ClientHandler)
-
-  val handledEventCount: Int
 }

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/V086UserEventHandler.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/V086UserEventHandler.kt
@@ -8,6 +8,4 @@ interface V086UserEventHandler<in T : UserEvent?> {
   override fun toString(): String
 
   fun handleEvent(event: T, clientHandler: V086ClientHandler)
-
-  val handledEventCount: Int
 }


### PR DESCRIPTION
An NPE gets thrown if a user tries to create or join a game when they are not fully logged into the server. This might happen if the user gets timed out but for some reason the client doesn't seem to know..

Also remove some counters that are never used.