### PR TITLE
Lower threshold for noticable lag from 0.5s/1m to 0.3s/1m

### DIFF
--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameChatAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameChatAction.kt
@@ -495,7 +495,7 @@ class GameChatAction(
         val p1 = game.players.firstOrNull()
         if (p1 != null && p1.connectionType == ConnectionType.LAN && lagstatDuration > 10.seconds) {
           val lagPerDuration = game.currentGameLag / lagstatDuration
-          if (lagPerDuration > 0.5.seconds / 1.minutes) {
+          if (lagPerDuration > 0.3.seconds / 1.minutes) {
             val laggiestPlayer = game.players.maxBy { it.lagAttributedToUser() }
             if (laggiestPlayer.lagAttributedToUser() > Duration.ZERO) {
               val targetFrameDelay = laggiestPlayer.frameDelay + 1


### PR DESCRIPTION
We should also consider tracking shorter and longer-term lag.

For example, a noticeable but brief lag spike may not exceed 0.5s/1m but it should still be recognized if the user immediately uses `/lagstat`.