### PR TITLE
Handle IOException when making HTTP requests

### DIFF
--- a/emulinker/src/main/java/org/emulinker/kaillera/master/client/EmuLinkerMasterUpdateTask.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/master/client/EmuLinkerMasterUpdateTask.kt
@@ -8,6 +8,7 @@ import java.io.InputStreamReader
 import java.net.HttpURLConnection
 import java.net.URL
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeUnit.HOURS
 import org.emulinker.config.RuntimeFlags
 import org.emulinker.kaillera.master.PublicServerInformation
 import org.emulinker.kaillera.model.GameStatus
@@ -37,7 +38,13 @@ class EmuLinkerMasterUpdateTask(
       this.append("version", releaseInfo.versionWithElkPrefix.take(30))
     }
 
-    val connection: HttpURLConnection = URL(url.buildString()).openConnection() as HttpURLConnection
+    val connection: HttpURLConnection =
+      try {
+        URL(url.buildString()).openConnection() as HttpURLConnection
+      } catch (e: IOException) {
+        logger.atWarning().withCause(e).atMostEvery(6, HOURS).log("Failed to open http connection")
+        return
+      }
     connection.setRequestMethod("GET")
     connection.connectTimeout = 2_000 // milliseconds
     connection.readTimeout = 2_000 // milliseconds

--- a/emulinker/src/main/java/org/emulinker/kaillera/master/client/KailleraMasterUpdateTask.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/master/client/KailleraMasterUpdateTask.kt
@@ -8,6 +8,7 @@ import java.io.InputStreamReader
 import java.net.HttpURLConnection
 import java.net.URL
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeUnit.HOURS
 import org.emulinker.config.RuntimeFlags
 import org.emulinker.kaillera.master.PublicServerInformation
 import org.emulinker.kaillera.master.StatsCollector
@@ -52,7 +53,13 @@ class KailleraMasterUpdateTask(
       this.append("url", publicInfo.website)
     }
 
-    val connection: HttpURLConnection = URL(url.buildString()).openConnection() as HttpURLConnection
+    val connection: HttpURLConnection =
+      try {
+        URL(url.buildString()).openConnection() as HttpURLConnection
+      } catch (e: IOException) {
+        logger.atWarning().withCause(e).atMostEvery(6, HOURS).log("Failed to open http connection")
+        return
+      }
     connection.setRequestMethod("GET")
     connection.connectTimeout = 2_000 // milliseconds
     connection.readTimeout = 2_000 // milliseconds

--- a/emulinker/src/main/java/org/emulinker/kaillera/master/client/ServerCheckinTask.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/master/client/ServerCheckinTask.kt
@@ -4,6 +4,7 @@ import com.google.common.flogger.FluentLogger
 import io.ktor.utils.io.charsets.name
 import java.io.BufferedReader
 import java.io.DataOutputStream
+import java.io.IOException
 import java.io.InputStreamReader
 import java.net.HttpURLConnection
 import java.net.URL
@@ -72,8 +73,13 @@ class ServerCheckinTask(
 
   /** @return Whether or not the RPC succeeded. */
   private fun touchMasterWithUrl(url: URL): CheckinResponse? {
-
-    val connection: HttpURLConnection = url.openConnection() as HttpURLConnection
+    val connection: HttpURLConnection =
+      try {
+        url.openConnection() as HttpURLConnection
+      } catch (e: IOException) {
+        logger.atWarning().withCause(e).atMostEvery(6, HOURS).log("Failed to open http connection")
+        return null
+      }
     connection.setRequestMethod("POST")
     connection.setRequestProperty("Content-Type", "application/json")
     connection.setDoOutput(true) // idk if we need this

--- a/emulinker/src/main/java/org/emulinker/util/TaskScheduler.kt
+++ b/emulinker/src/main/java/org/emulinker/util/TaskScheduler.kt
@@ -37,8 +37,17 @@ class TaskScheduler {
       try {
         logger.atFine().log("Starting scheduled task: %s", taskName)
         action()
+      } catch (e: InterruptedException) {
+        // The server was probably told to shut down.
+        throw e
       } catch (e: Exception) {
-        logger.atSevere().withCause(e).log("Exception in scheduled task!")
+        logger.atSevere().withCause(e).log("Exception in scheduled task! Discarding.")
+      } catch (e: Throwable) {
+        // Some throwables such as IOException do not actually extend Exception and could break
+        // execution of the task
+        // scheduler. Allow it to break the scheduler, but log that it happened.
+        logger.atSevere().withCause(e).log("Throwable in scheduled task. Rethrowing!")
+        throw e
       } finally {
         logger.atFine().log("Completed scheduled task: %s", taskName)
       }


### PR DESCRIPTION
It turns out `IOException` is not a `RuntimeException`.

Probably fixes #223