### PR TITLE
Add /permaban and /permamute, and other improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,44 @@ game) or @restart (meaning they are restarting the game and are waiting for the 
 tweets sent. Similarly, users will be notified and given 20 seconds to type `/stop` to stop the tweet from sending.
 After the game starts, the account will respond to the original tweet with the text "(opponent found)".
 
+## Server Extensions
+
+This server extends the original Kaillera/EmuLinkerSF protocol and admin toolset with additional features. All extensions are **backwards compatible** — existing clients behave identically without needing any changes. However, some features are only accessible to users with sufficient access levels (admin, superadmin).
+
+### Admin Commands
+
+EmuLinker-K adds the following admin chat commands on top of the standard set. Commands are entered in the server lobby chat.
+
+> [!NOTE]
+> Optional `<reason>` arguments are **internal only** — the reason is recorded in logs and viewable via `/info`, but is never revealed to the affected user or broadcast to the server.
+
+| Command | Access | Description |
+|---|---|---|
+| `/ban <UserID> <minutes> [reason]` | Moderator+ | Temporarily ban a user by UserID. The optional `reason` is recorded internally. |
+| `/silence <UserID> <minutes> [reason]` | Moderator+ | Temporarily silence (mute) a user. The optional `reason` is recorded internally. |
+| `/permaban <UserID> [reason]` | Admin+ | Permanently bans a user. Writes an `ipaddress,DENY` entry to `access.cfg` with a comment recording the issuer, timestamp, and optional reason. |
+| `/permamute <UserID> [reason]` | Admin+ | Permanently silences a user. Writes a `silence` entry to `access.cfg` with a comment recording the issuer, timestamp, and optional reason. |
+| `/clear <IP \| UserID \| Name>` | Admin+ | Clears all temporary bans and silences for a user. Accepts an IP address, UserID number, or exact username (case-insensitive). |
+| `/info <IP \| UserID \| Name>` | Admin+ | Displays a user's access level and any active temporary restrictions (with issuer and reason) as private messages to the requesting admin. |
+
+#### Backwards Compatibility Note
+
+The `reason` parameter on `/ban` and `/silence` is optional and appended after the required arguments. Old client UIs that issue these commands automatically (e.g. `"/ban 1 10"`) will continue to work without modification.
+
+### `access.cfg` Persistent Bans and Silences
+
+The standard `access.cfg` format is extended with a new `silence` entry type for persistent mutes:
+
+```
+# Permanent silence issued by AdminName on 2026-01-01T00:00:00
+# Reason: Hate speech
+silence,10.0.0.42
+```
+
+When `/permaban` or `/permamute` is used, the server appends the appropriate rule to `access.cfg` along with a comment block. The file is automatically reloaded without a server restart.
+
+The `access.cfg` file is monitored for changes. Any manual edits (e.g., removing a ban entry to lift a permanent ban) will take effect automatically on the next server check.
+
 ## Legal Disclaimer
 
 Server administrators are solely responsible for ensuring that their data collection, disclosure, and retention

--- a/emulinker/src/jmh/java/org/emulinker/kaillera/controller/GameDataBenchmark.kt
+++ b/emulinker/src/jmh/java/org/emulinker/kaillera/controller/GameDataBenchmark.kt
@@ -473,7 +473,12 @@ open class GameDataBenchmark {
 
     override fun getAnnouncement(address: InetAddress): String? = null
 
-    override fun addTempBan(addressPattern: String, duration: Duration) {}
+    override fun addTempBan(
+      addressPattern: String,
+      duration: Duration,
+      issuer: String?,
+      reason: String?,
+    ) {}
 
     override fun addTempAdmin(addressPattern: String, duration: Duration) {}
 
@@ -481,9 +486,22 @@ open class GameDataBenchmark {
 
     override fun addTempElevated(addressPattern: String, duration: Duration) {}
 
-    override fun addSilenced(addressPattern: String, duration: Duration) {}
+    override fun addSilenced(
+      addressPattern: String,
+      duration: Duration,
+      issuer: String?,
+      reason: String?,
+    ) {}
 
     override fun clearTemp(address: InetAddress, clearAll: Boolean): Boolean = false
+
+    override fun addPermaBan(addressPattern: String, issuer: String?, reason: String?) {}
+
+    override fun addPermaMute(addressPattern: String, issuer: String?, reason: String?) {}
+
+    override fun getTempBan(address: InetAddress): org.emulinker.kaillera.access.TempBan? = null
+
+    override fun getSilence(address: InetAddress): org.emulinker.kaillera.access.Silence? = null
 
     override fun close() {}
   }

--- a/emulinker/src/jmh/java/org/emulinker/kaillera/controller/LoginBenchmark.kt
+++ b/emulinker/src/jmh/java/org/emulinker/kaillera/controller/LoginBenchmark.kt
@@ -277,7 +277,12 @@ open class LoginBenchmark : KoinComponent {
 
     override fun getAnnouncement(address: InetAddress): String? = null
 
-    override fun addTempBan(addressPattern: String, duration: Duration) {}
+    override fun addTempBan(
+      addressPattern: String,
+      duration: Duration,
+      issuer: String?,
+      reason: String?,
+    ) {}
 
     override fun addTempAdmin(addressPattern: String, duration: Duration) {}
 
@@ -285,9 +290,22 @@ open class LoginBenchmark : KoinComponent {
 
     override fun addTempElevated(addressPattern: String, duration: Duration) {}
 
-    override fun addSilenced(addressPattern: String, duration: Duration) {}
+    override fun addSilenced(
+      addressPattern: String,
+      duration: Duration,
+      issuer: String?,
+      reason: String?,
+    ) {}
 
     override fun clearTemp(address: InetAddress, clearAll: Boolean): Boolean = false
+
+    override fun addPermaBan(addressPattern: String, issuer: String?, reason: String?) {}
+
+    override fun addPermaMute(addressPattern: String, issuer: String?, reason: String?) {}
+
+    override fun getTempBan(address: InetAddress): org.emulinker.kaillera.access.TempBan? = null
+
+    override fun getSilence(address: InetAddress): org.emulinker.kaillera.access.Silence? = null
 
     override fun close() {}
   }

--- a/emulinker/src/jmh/java/org/emulinker/kaillera/controller/PingBenchmark.kt
+++ b/emulinker/src/jmh/java/org/emulinker/kaillera/controller/PingBenchmark.kt
@@ -96,7 +96,12 @@ open class PingBenchmark : KoinComponent {
 
     override fun getAnnouncement(address: InetAddress): String? = null
 
-    override fun addTempBan(addressPattern: String, duration: Duration) {}
+    override fun addTempBan(
+      addressPattern: String,
+      duration: Duration,
+      issuer: String?,
+      reason: String?,
+    ) {}
 
     override fun addTempAdmin(addressPattern: String, duration: Duration) {}
 
@@ -104,9 +109,22 @@ open class PingBenchmark : KoinComponent {
 
     override fun addTempElevated(addressPattern: String, duration: Duration) {}
 
-    override fun addSilenced(addressPattern: String, duration: Duration) {}
+    override fun addSilenced(
+      addressPattern: String,
+      duration: Duration,
+      issuer: String?,
+      reason: String?,
+    ) {}
 
     override fun clearTemp(address: InetAddress, clearAll: Boolean): Boolean = false
+
+    override fun addPermaBan(addressPattern: String, issuer: String?, reason: String?) {}
+
+    override fun addPermaMute(addressPattern: String, issuer: String?, reason: String?) {}
+
+    override fun getTempBan(address: InetAddress): org.emulinker.kaillera.access.TempBan? = null
+
+    override fun getSilence(address: InetAddress): org.emulinker.kaillera.access.Silence? = null
 
     override fun close() {}
   }

--- a/emulinker/src/main/java/org/emulinker/kaillera/access/AccessManager.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/access/AccessManager.kt
@@ -65,9 +65,16 @@ interface AccessManager : Closeable {
    * [getAccess] should return [ACCESS_BANNED].
    *
    * @param addressPattern A pattern to match to an address
-   * @param minutes Number of minutes this ban is valid from the time of addition
+   * @param duration Duration this ban is valid from the time of addition
+   * @param issuer The admin who issued the ban
+   * @param reason The internal reason for the ban
    */
-  fun addTempBan(addressPattern: String, duration: Duration)
+  fun addTempBan(
+    addressPattern: String,
+    duration: Duration,
+    issuer: String? = null,
+    reason: String? = null,
+  )
 
   /**
    * Temporarily adds a user to the admin list using a pattern algorithm defined by the
@@ -87,11 +94,26 @@ interface AccessManager : Closeable {
    * AccessManager implementation. While active, [isSilenced] should return `true ` * .
    *
    * @param addressPattern A pattern to match to an address
-   * @param minutes Number of minutes this grant is valid from the time of addition
+   * @param duration Duration this grant is valid from the time of addition
+   * @param issuer The admin who issued the silence
+   * @param reason The internal reason for the silence
    */
-  fun addSilenced(addressPattern: String, duration: Duration)
+  fun addSilenced(
+    addressPattern: String,
+    duration: Duration,
+    issuer: String? = null,
+    reason: String? = null,
+  )
 
   fun clearTemp(address: InetAddress, clearAll: Boolean): Boolean
+
+  fun addPermaBan(addressPattern: String, issuer: String? = null, reason: String? = null)
+
+  fun addPermaMute(addressPattern: String, issuer: String? = null, reason: String? = null)
+
+  fun getTempBan(address: InetAddress): TempBan?
+
+  fun getSilence(address: InetAddress): Silence?
 
   companion object {
     const val ACCESS_BANNED = 0

--- a/emulinker/src/main/java/org/emulinker/kaillera/access/AccessManager2.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/access/AccessManager2.kt
@@ -44,6 +44,7 @@ class AccessManager2(private val flags: RuntimeFlags, private val taskScheduler:
   private val tempModeratorList: MutableList<TempModerator> = CopyOnWriteArrayList()
   private val tempElevatedList: MutableList<TempElevated> = CopyOnWriteArrayList()
   private val silenceList: MutableList<Silence> = CopyOnWriteArrayList()
+  private val permaSilenceList: MutableList<SilenceAccess> = CopyOnWriteArrayList()
 
   private val timerTasks = mutableSetOf<ScheduledFuture<*>>()
 
@@ -64,6 +65,7 @@ class AccessManager2(private val flags: RuntimeFlags, private val taskScheduler:
     gameList.clear()
     emulatorList.clear()
     addressList.clear()
+    permaSilenceList.clear()
     try {
       val file = FileInputStream(af)
       val temp: Reader = InputStreamReader(file, flags.charset)
@@ -82,6 +84,7 @@ class AccessManager2(private val flags: RuntimeFlags, private val taskScheduler:
           "game" -> gameList.add(GameAccess(st))
           "emulator" -> emulatorList.add(EmulatorAccess(st))
           "ipaddress" -> addressList.add(AddressAccess(st))
+          "silence" -> permaSilenceList.add(SilenceAccess(st))
           else ->
             logger
               .atSevere()
@@ -94,8 +97,13 @@ class AccessManager2(private val flags: RuntimeFlags, private val taskScheduler:
     }
   }
 
-  override fun addTempBan(addressPattern: String, duration: Duration) {
-    addTemporaryAttributeToList(tempBanList, TempBan(addressPattern, duration))
+  override fun addTempBan(
+    addressPattern: String,
+    duration: Duration,
+    issuer: String?,
+    reason: String?,
+  ) {
+    addTemporaryAttributeToList(tempBanList, TempBan(addressPattern, duration, issuer, reason))
   }
 
   override fun addTempAdmin(addressPattern: String, duration: Duration) {
@@ -110,8 +118,57 @@ class AccessManager2(private val flags: RuntimeFlags, private val taskScheduler:
     addTemporaryAttributeToList(tempElevatedList, TempElevated(addressPattern, duration))
   }
 
-  override fun addSilenced(addressPattern: String, duration: Duration) {
-    addTemporaryAttributeToList(silenceList, Silence(addressPattern, duration))
+  override fun addSilenced(
+    addressPattern: String,
+    duration: Duration,
+    issuer: String?,
+    reason: String?,
+  ) {
+    addTemporaryAttributeToList(silenceList, Silence(addressPattern, duration, issuer, reason))
+  }
+
+  @Synchronized
+  override fun addPermaBan(addressPattern: String, issuer: String?, reason: String?) {
+    val file = accessFile ?: return
+    try {
+      java.io.FileWriter(file, true).use { writer ->
+        writer.appendLine()
+        writer.appendLine("# Permanent ban issued by ${issuer ?: "Unknown"}")
+        if (reason != null) writer.appendLine("# Reason: $reason")
+        writer.appendLine("ipaddress,DENY,$addressPattern")
+      }
+      loadAccess()
+    } catch (e: Exception) {
+      logger.atSevere().withCause(e).log("Failed to write to access file")
+    }
+  }
+
+  @Synchronized
+  override fun addPermaMute(addressPattern: String, issuer: String?, reason: String?) {
+    val file = accessFile ?: return
+    try {
+      java.io.FileWriter(file, true).use { writer ->
+        writer.appendLine()
+        writer.appendLine("# Permanent silence issued by ${issuer ?: "Unknown"}")
+        if (reason != null) writer.appendLine("# Reason: $reason")
+        writer.appendLine("silence,$addressPattern")
+      }
+      loadAccess()
+    } catch (e: Exception) {
+      logger.atSevere().withCause(e).log("Failed to write to access file")
+    }
+  }
+
+  override fun getTempBan(address: InetAddress): TempBan? {
+    checkReload()
+    val userAddress = address.hostAddress
+    return tempBanList.firstOrNull { it.matches(userAddress) && !it.isExpired }
+  }
+
+  override fun getSilence(address: InetAddress): Silence? {
+    checkReload()
+    val userAddress = address.hostAddress
+    return silenceList.firstOrNull { it.matches(userAddress) && !it.isExpired }
   }
 
   private fun <T : TemporaryAttribute> addTemporaryAttributeToList(
@@ -199,6 +256,9 @@ class AccessManager2(private val flags: RuntimeFlags, private val taskScheduler:
     val userAddress = address.hostAddress
     for (silence in silenceList) {
       if (silence.matches(userAddress) && !silence.isExpired) return true
+    }
+    for (silence in permaSilenceList) {
+      if (silence.matches(userAddress)) return true
     }
     return false
   }
@@ -437,6 +497,69 @@ class AccessManager2(private val flags: RuntimeFlags, private val taskScheduler:
     }
   }
 
+  private class SilenceAccess(st: StringTokenizer) {
+    private var hostNames: MutableList<String>
+    private var resolvedAddresses: MutableList<String>
+
+    @Synchronized
+    fun refreshDNS() {
+      resolvedAddresses.clear()
+      for (hostName in hostNames) {
+        try {
+          val address = InetAddress.getByName(hostName)
+          resolvedAddresses.add(address.hostAddress)
+        } catch (e: Exception) {
+          logger
+            .atFine()
+            .withCause(e)
+            .log("Failed to resolve DNS entry to an address: %s", hostName)
+        }
+      }
+    }
+
+    private var patterns: MutableList<WildcardStringPattern>
+
+    @Synchronized
+    fun matches(address: String): Boolean {
+      for (pattern in patterns) {
+        if (pattern.match(address)) return true
+      }
+      for (resolvedAddress in resolvedAddresses) {
+        if (resolvedAddress == address) return true
+      }
+      return false
+    }
+
+    init {
+      if (st.countTokens() != 1) throw Exception("Wrong number of tokens: " + st.countTokens())
+      hostNames = ArrayList()
+      resolvedAddresses = ArrayList()
+      patterns = ArrayList()
+      val s = st.nextToken().lowercase(Locale.getDefault())
+      val pt = StringTokenizer(s, "|")
+      while (pt.hasMoreTokens()) {
+        val pat = pt.nextToken().lowercase(Locale.getDefault())
+        if (pat.startsWith("dns:")) {
+          if (pat.length <= 5) throw AccessException("Malformatted DNS entry: $s")
+          val hostName = pat.substring(4)
+          try {
+            val a = InetAddress.getByName(hostName)
+            logger.atFine().log("Resolved %s to %s", hostName, a.hostAddress)
+          } catch (e: Exception) {
+            logger
+              .atWarning()
+              .withCause(e)
+              .log("Failed to resolve DNS entry to an address: %s", hostName)
+          }
+          hostNames.add(pat.substring(4))
+        } else {
+          patterns.add(WildcardStringPattern(pat))
+        }
+      }
+      refreshDNS()
+    }
+  }
+
   init {
     val url = AccessManager2::class.java.getResource("/access.cfg")
     requireNotNull(url) { "Resource not found: /access.conf" }
@@ -463,6 +586,7 @@ class AccessManager2(private val flags: RuntimeFlags, private val taskScheduler:
       ) {
         userList.forEach { it.refreshDNS() }
         addressList.forEach { it.refreshDNS() }
+        permaSilenceList.forEach { it.refreshDNS() }
       }
     )
   }

--- a/emulinker/src/main/java/org/emulinker/kaillera/access/AccessManager2.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/access/AccessManager2.kt
@@ -74,11 +74,19 @@ class AccessManager2(private val flags: RuntimeFlags, private val taskScheduler:
       while (reader.readLine().also { line = it } != null) {
         if (line.isNullOrBlank() || line!!.startsWith("#") || line!!.startsWith("//")) continue
         val st = StringTokenizer(line, ",")
-        if (st.countTokens() < 3) {
+        val tokenCount = st.countTokens()
+        if (tokenCount < 2) {
           logger.atSevere().log("Failed to load access line, too few tokens: %s", line)
           continue
         }
         val type = st.nextToken()
+        // silence lines have the format `silence,<address>` (2 tokens total, 1 remaining after
+        // type)
+        // all other lines need at least 2 more tokens (3 total)
+        if (type.lowercase() != "silence" && tokenCount < 3) {
+          logger.atSevere().log("Failed to load access line, too few tokens: %s", line)
+          continue
+        }
         when (type.lowercase()) {
           "user" -> userList.add(UserAccess(st))
           "game" -> gameList.add(GameAccess(st))

--- a/emulinker/src/main/java/org/emulinker/kaillera/access/TemporaryAttribute.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/access/TemporaryAttribute.kt
@@ -4,7 +4,12 @@ import java.util.Locale
 import kotlin.time.Duration
 import org.emulinker.util.WildcardStringPattern
 
-sealed class TemporaryAttribute(accessStr: String, val duration: Duration) {
+sealed class TemporaryAttribute(
+  accessStr: String,
+  val duration: Duration,
+  val issuer: String? = null,
+  val reason: String? = null,
+) {
   private val patterns: List<WildcardStringPattern> =
     accessStr.lowercase(Locale.getDefault()).split("|").map { WildcardStringPattern(it) }
 
@@ -18,7 +23,12 @@ sealed class TemporaryAttribute(accessStr: String, val duration: Duration) {
   }
 }
 
-class TempBan(accessStr: String, duration: Duration) : TemporaryAttribute(accessStr, duration)
+class TempBan(
+  accessStr: String,
+  duration: Duration,
+  issuer: String? = null,
+  reason: String? = null,
+) : TemporaryAttribute(accessStr, duration, issuer, reason)
 
 class TempAdmin(accessStr: String, duration: Duration) : TemporaryAttribute(accessStr, duration)
 
@@ -26,4 +36,9 @@ class TempModerator(accessStr: String, duration: Duration) : TemporaryAttribute(
 
 class TempElevated(accessStr: String, duration: Duration) : TemporaryAttribute(accessStr, duration)
 
-class Silence(accessStr: String, duration: Duration) : TemporaryAttribute(accessStr, duration)
+class Silence(
+  accessStr: String,
+  duration: Duration,
+  issuer: String? = null,
+  reason: String? = null,
+) : TemporaryAttribute(accessStr, duration, issuer, reason)

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/AdminCommandAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/AdminCommandAction.kt
@@ -39,7 +39,10 @@ class AdminCommandAction : V086Action<Chat> {
         chat.startsWith(COMMAND_TEMPELEVATED) ||
         chat.startsWith(COMMAND_TEMPMODERATOR) ||
         chat.startsWith(COMMAND_TRIVIA) ||
-        chat.startsWith(COMMAND_VERSION) -> true
+        chat.startsWith(COMMAND_VERSION) ||
+        chat.startsWith(COMMAND_PERMABAN) ||
+        chat.startsWith(COMMAND_PERMAMUTE) ||
+        chat.startsWith(COMMAND_INFO) -> true
       else -> false
     }
   }
@@ -124,6 +127,15 @@ class AdminCommandAction : V086Action<Chat> {
         }
         chat.startsWith(COMMAND_TRIVIA) -> {
           processTrivia(chat, server, user, clientHandler)
+        }
+        chat.startsWith(COMMAND_PERMABAN) -> {
+          processPermaBan(chat, server, user, clientHandler)
+        }
+        chat.startsWith(COMMAND_PERMAMUTE) -> {
+          processPermaMute(chat, server, user, clientHandler)
+        }
+        chat.startsWith(COMMAND_INFO) -> {
+          processInfo(chat, server, user, clientHandler)
         }
         else -> throw ActionException("Invalid Command: $chat")
       }
@@ -304,6 +316,15 @@ class AdminCommandAction : V086Action<Chat> {
       scanner.next()
       val userID = scanner.nextInt()
       val minutes = scanner.nextInt()
+      val reasonStr =
+        if (scanner.hasNext()) {
+          val sb = java.lang.StringBuilder()
+          while (scanner.hasNext()) {
+            sb.append(scanner.next()).append(" ")
+          }
+          sb.toString().trim()
+        } else null
+
       val user =
         server.getUser(userID)
           ?: throw ActionException(EmuLang.getString("AdminCommandAction.UserNotFound", +userID))
@@ -329,6 +350,8 @@ class AdminCommandAction : V086Action<Chat> {
       server.accessManager.addSilenced(
         user.connectSocketAddress.address.hostAddress,
         minutes.minutes,
+        admin.name,
+        reasonStr,
       )
       server.announce(
         EmuLang.getString("AdminCommandAction.Silenced", minutes, user.name),
@@ -412,6 +435,15 @@ class AdminCommandAction : V086Action<Chat> {
       scanner.next()
       val userID = scanner.nextInt()
       val minutes = scanner.nextInt()
+      val reasonStr =
+        if (scanner.hasNext()) {
+          val sb = java.lang.StringBuilder()
+          while (scanner.hasNext()) {
+            sb.append(scanner.next()).append(" ")
+          }
+          sb.toString().trim()
+        } else null
+
       val user =
         server.getUser(userID)
           ?: throw ActionException(EmuLang.getString("AdminCommandAction.UserNotFound", userID))
@@ -431,6 +463,8 @@ class AdminCommandAction : V086Action<Chat> {
       server.accessManager.addTempBan(
         user.connectSocketAddress.address.hostAddress,
         minutes.minutes,
+        admin.name,
+        reasonStr,
       )
     } catch (e: NoSuchElementException) {
       throw ActionException(EmuLang.getString("AdminCommandAction.BanError"))
@@ -739,16 +773,30 @@ class AdminCommandAction : V086Action<Chat> {
   ) {
     val space = message.indexOf(' ')
     if (space < 0) throw ActionException(EmuLang.getString("AdminCommandAction.ClearError"))
-    val addressStr = message.substring(space + 1)
-    val inetAddr: InetAddress =
-      try {
-        InetAddress.getByName(addressStr)
-      } catch (e: Exception) {
-        throw ActionException(EmuLang.getString("AdminCommandAction.ClearAddressFormatError"))
+    val targetStr = message.substring(space + 1).trim()
+
+    var inetAddr: InetAddress? = null
+    try {
+      inetAddr = InetAddress.getByName(targetStr)
+    } catch (e: Exception) {
+      val targetId = targetStr.toIntOrNull()
+      val matchedUser =
+        if (targetId != null) {
+          server.getUser(targetId)
+        } else {
+          server.usersMap.values.firstOrNull { it.name.equals(targetStr, ignoreCase = true) }
+        }
+
+      if (matchedUser != null) {
+        inetAddr = matchedUser.connectSocketAddress.address
+      } else {
+        throw ActionException("Could not find user with ID, IP or Name: $targetStr")
       }
+    }
+
     if (
       admin.accessLevel == AccessManager.ACCESS_SUPERADMIN &&
-        server.accessManager.clearTemp(inetAddr, true) ||
+        server.accessManager.clearTemp(inetAddr!!, true) ||
         admin.accessLevel == AccessManager.ACCESS_ADMIN &&
           server.accessManager.clearTemp(inetAddr, false)
     )
@@ -820,6 +868,172 @@ class AdminCommandAction : V086Action<Chat> {
     }
   }
 
+  @Throws(ActionException::class, MessageFormatException::class)
+  private fun processPermaBan(
+    message: String,
+    server: KailleraServer,
+    admin: KailleraUser,
+    clientHandler: V086ClientHandler?,
+  ) {
+    if (
+      admin.accessLevel != AccessManager.ACCESS_SUPERADMIN &&
+        admin.accessLevel != AccessManager.ACCESS_ADMIN
+    ) {
+      throw ActionException("You don't have access to permaban.")
+    }
+    val scanner = Scanner(message).useDelimiter(" ")
+    try {
+      scanner.next()
+      val userID = scanner.nextInt()
+      val reasonStr =
+        if (scanner.hasNext()) {
+          val sb = java.lang.StringBuilder()
+          while (scanner.hasNext()) {
+            sb.append(scanner.next()).append(" ")
+          }
+          sb.toString().trim()
+        } else null
+
+      val user =
+        server.getUser(userID)
+          ?: throw ActionException(EmuLang.getString("AdminCommandAction.UserNotFound", userID))
+      if (user.id == admin.id) throw ActionException("Can not permaban yourself.")
+      val access = server.accessManager.getAccess(user.connectSocketAddress.address)
+      if (
+        access >= AccessManager.ACCESS_ADMIN && admin.accessLevel != AccessManager.ACCESS_SUPERADMIN
+      )
+        throw ActionException("Can not permaban an admin.")
+
+      server.accessManager.addPermaBan(
+        user.connectSocketAddress.address.hostAddress,
+        admin.name,
+        reasonStr,
+      )
+      server.announce("Admin ${admin.name} permanently banned ${user.name}!", false, null)
+      user.quit("You have been permanently banned.")
+    } catch (e: NoSuchElementException) {
+      throw ActionException("Permaban Error: /permaban <UserID> <Optional Reason>")
+    }
+  }
+
+  @Throws(ActionException::class, MessageFormatException::class)
+  private fun processPermaMute(
+    message: String,
+    server: KailleraServer,
+    admin: KailleraUser,
+    clientHandler: V086ClientHandler?,
+  ) {
+    if (
+      admin.accessLevel != AccessManager.ACCESS_SUPERADMIN &&
+        admin.accessLevel != AccessManager.ACCESS_ADMIN
+    ) {
+      throw ActionException("You don't have access to permamute.")
+    }
+    val scanner = Scanner(message).useDelimiter(" ")
+    try {
+      scanner.next()
+      val userID = scanner.nextInt()
+      val reasonStr =
+        if (scanner.hasNext()) {
+          val sb = java.lang.StringBuilder()
+          while (scanner.hasNext()) {
+            sb.append(scanner.next()).append(" ")
+          }
+          sb.toString().trim()
+        } else null
+
+      val user =
+        server.getUser(userID)
+          ?: throw ActionException(EmuLang.getString("AdminCommandAction.UserNotFound", userID))
+      if (user.id == admin.id) throw ActionException("Can not permamute yourself.")
+      val access = server.accessManager.getAccess(user.connectSocketAddress.address)
+      if (
+        access >= AccessManager.ACCESS_ADMIN && admin.accessLevel != AccessManager.ACCESS_SUPERADMIN
+      )
+        throw ActionException("Can not permamute an admin.")
+
+      server.accessManager.addPermaMute(
+        user.connectSocketAddress.address.hostAddress,
+        admin.name,
+        reasonStr,
+      )
+      server.announce("Admin ${admin.name} permanently muted ${user.name}!", false, null)
+    } catch (e: NoSuchElementException) {
+      throw ActionException("Permamute Error: /permamute <UserID> <Optional Reason>")
+    }
+  }
+
+  @Throws(ActionException::class, MessageFormatException::class)
+  private fun processInfo(
+    message: String,
+    server: KailleraServer,
+    admin: KailleraUser,
+    clientHandler: V086ClientHandler?,
+  ) {
+    if (admin.accessLevel < AccessManager.ACCESS_ADMIN) return
+    val space = message.indexOf(' ')
+    if (space < 0) throw ActionException("Usage: /info <IP, UserID, or Name>")
+    val targetStr = message.substring(space + 1).trim()
+
+    var inetAddr: InetAddress? = null
+    var userName = targetStr
+    try {
+      inetAddr = InetAddress.getByName(targetStr)
+    } catch (e: Exception) {
+      val targetId = targetStr.toIntOrNull()
+      val matchedUser =
+        if (targetId != null) {
+          server.getUser(targetId)
+        } else {
+          server.usersMap.values.firstOrNull { it.name.equals(targetStr, ignoreCase = true) }
+        }
+
+      if (matchedUser != null) {
+        inetAddr = matchedUser.connectSocketAddress.address
+        userName = matchedUser.name ?: "Unknown"
+      } else {
+        throw ActionException("Could not find user with ID, IP or Name: $targetStr")
+      }
+    }
+
+    val tempBan = server.accessManager.getTempBan(inetAddr!!)
+    val silence = server.accessManager.getSilence(inetAddr)
+    val access = server.accessManager.getAccess(inetAddr)
+
+    clientHandler!!.send(
+      InformationMessage(0, "server", "Info for $userName (${inetAddr.hostAddress}):")
+    )
+    clientHandler.send(
+      InformationMessage(
+        0,
+        "server",
+        "Access Level: ${AccessManager.ACCESS_NAMES.getOrNull(access) ?: access}",
+      )
+    )
+
+    if (tempBan != null) {
+      clientHandler.send(
+        InformationMessage(
+          0,
+          "server",
+          "Active Temp Ban: Issuer: ${tempBan.issuer}, Reason: ${tempBan.reason ?: "None"}",
+        )
+      )
+    }
+    if (silence != null) {
+      clientHandler.send(
+        InformationMessage(
+          0,
+          "server",
+          "Active Silence: Issuer: ${silence.issuer}, Reason: ${silence.reason ?: "None"}",
+        )
+      )
+    }
+    if (tempBan == null && silence == null) {
+      clientHandler.send(InformationMessage(0, "server", "No active temporary restrictions."))
+    }
+  }
+
   companion object {
     private val logger = FluentLogger.forEnclosingClass()
 
@@ -857,5 +1071,11 @@ class AdminCommandAction : V086Action<Chat> {
     private const val COMMAND_TEMPELEVATED = "/tempelevated"
 
     private const val COMMAND_TEMPMODERATOR = "/tempmoderator"
+
+    private const val COMMAND_PERMABAN = "/permaban"
+
+    private const val COMMAND_PERMAMUTE = "/permamute"
+
+    private const val COMMAND_INFO = "/info"
   }
 }

--- a/emulinker/src/test/java/org/emulinker/kaillera/access/AccessManager2Test.kt
+++ b/emulinker/src/test/java/org/emulinker/kaillera/access/AccessManager2Test.kt
@@ -1,0 +1,355 @@
+package org.emulinker.kaillera.access
+
+import com.google.common.truth.Truth.assertThat
+import java.io.File
+import java.net.InetAddress
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.minutes
+import org.emulinker.config.RuntimeFlags
+import org.emulinker.util.TaskScheduler
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class AccessManager2Test {
+
+  @get:Rule val tempFolder = TemporaryFolder()
+
+  private lateinit var accessFile: File
+  private lateinit var accessManager: AccessManager2
+  private lateinit var taskScheduler: TaskScheduler
+
+  private val localIp: InetAddress = InetAddress.getByName("127.0.0.1")
+  private val remoteIp: InetAddress = InetAddress.getByName("10.0.0.42")
+  private val otherIp: InetAddress = InetAddress.getByName("192.168.1.1")
+
+  @Before
+  fun setUp() {
+    // Start with an empty access file — isAddressAllowed() defaults to `true` when no rule matches.
+    accessFile = tempFolder.newFile("access.cfg").also { it.writeText("") }
+    taskScheduler = TaskScheduler()
+    accessManager = buildAccessManager(accessFile)
+  }
+
+  @After
+  fun tearDown() {
+    accessManager.close()
+  }
+
+  /** Constructs an [AccessManager2] pointed at [file] instead of the classpath resource. */
+  private fun buildAccessManager(file: File): AccessManager2 {
+    // AccessManager2's `init` block reads from the classpath. We create an instance normally
+    // (which loads the real access.cfg from the classpath), then immediately swap `accessFile`
+    // and reload so all tests operate against our temp file.
+    val instance = AccessManager2(buildFlags(), taskScheduler)
+    val field = AccessManager2::class.java.getDeclaredField("accessFile")
+    field.isAccessible = true
+    field.set(instance, file)
+    instance.forceReload()
+    return instance
+  }
+
+  // ── TemporaryAttribute tests ────────────────────────────────────────────────
+
+  @Test
+  fun tempBan_storesIssuerAndReason() {
+    val ban = TempBan("10.0.0.42", 10.minutes, issuer = "Admin1", reason = "Cheating")
+    assertThat(ban.issuer).isEqualTo("Admin1")
+    assertThat(ban.reason).isEqualTo("Cheating")
+    assertThat(ban.isExpired).isFalse()
+  }
+
+  @Test
+  fun tempBan_defaultsIssuerAndReasonToNull() {
+    val ban = TempBan("10.0.0.42", 10.minutes)
+    assertThat(ban.issuer).isNull()
+    assertThat(ban.reason).isNull()
+  }
+
+  @Test
+  fun silence_storesIssuerAndReason() {
+    val silence = Silence("10.0.0.42", 5.minutes, issuer = "Mod1", reason = "Spamming")
+    assertThat(silence.issuer).isEqualTo("Mod1")
+    assertThat(silence.reason).isEqualTo("Spamming")
+    assertThat(silence.isExpired).isFalse()
+  }
+
+  @Test
+  fun tempBan_isExpiredAfterDuration() {
+    val ban = TempBan("10.0.0.42", 1.milliseconds)
+    Thread.sleep(10)
+    assertThat(ban.isExpired).isTrue()
+  }
+
+  @Test
+  fun silence_isExpiredAfterDuration() {
+    val s = Silence("10.0.0.42", 1.milliseconds)
+    Thread.sleep(10)
+    assertThat(s.isExpired).isTrue()
+  }
+
+  // ── addTempBan tests ────────────────────────────────────────────────────────
+
+  @Test
+  fun addTempBan_blocksAddress() {
+    assertThat(accessManager.isAddressAllowed(remoteIp)).isTrue()
+    accessManager.addTempBan(remoteIp.hostAddress, 10.minutes)
+    assertThat(accessManager.isAddressAllowed(remoteIp)).isFalse()
+  }
+
+  @Test
+  fun addTempBan_doesNotBlockOtherAddresses() {
+    accessManager.addTempBan(remoteIp.hostAddress, 10.minutes)
+    assertThat(accessManager.isAddressAllowed(otherIp)).isTrue()
+  }
+
+  @Test
+  fun addTempBan_storesIssuerAndReasonOnTempBanEntry() {
+    accessManager.addTempBan(remoteIp.hostAddress, 10.minutes, issuer = "Admin", reason = "Flood")
+    val ban = accessManager.getTempBan(remoteIp)
+    assertThat(ban).isNotNull()
+    assertThat(ban!!.issuer).isEqualTo("Admin")
+    assertThat(ban.reason).isEqualTo("Flood")
+  }
+
+  @Test
+  fun getTempBan_returnsNullWhenNotBanned() {
+    assertThat(accessManager.getTempBan(remoteIp)).isNull()
+  }
+
+  @Test
+  fun addTempBan_withoutOptionalArgs_stillWorks() {
+    accessManager.addTempBan(remoteIp.hostAddress, 10.minutes)
+    assertThat(accessManager.isAddressAllowed(remoteIp)).isFalse()
+    val ban = accessManager.getTempBan(remoteIp)
+    assertThat(ban).isNotNull()
+    assertThat(ban!!.issuer).isNull()
+    assertThat(ban.reason).isNull()
+  }
+
+  // ── addSilenced tests ───────────────────────────────────────────────────────
+
+  @Test
+  fun addSilenced_silencesAddress() {
+    assertThat(accessManager.isSilenced(remoteIp)).isFalse()
+    accessManager.addSilenced(remoteIp.hostAddress, 10.minutes)
+    assertThat(accessManager.isSilenced(remoteIp)).isTrue()
+  }
+
+  @Test
+  fun addSilenced_doesNotSilenceOtherAddresses() {
+    accessManager.addSilenced(remoteIp.hostAddress, 10.minutes)
+    assertThat(accessManager.isSilenced(otherIp)).isFalse()
+  }
+
+  @Test
+  fun addSilenced_storesIssuerAndReasonOnSilenceEntry() {
+    accessManager.addSilenced(remoteIp.hostAddress, 10.minutes, issuer = "Mod", reason = "Abuse")
+    val silence = accessManager.getSilence(remoteIp)
+    assertThat(silence).isNotNull()
+    assertThat(silence!!.issuer).isEqualTo("Mod")
+    assertThat(silence.reason).isEqualTo("Abuse")
+  }
+
+  @Test
+  fun getSilence_returnsNullWhenNotSilenced() {
+    assertThat(accessManager.getSilence(remoteIp)).isNull()
+  }
+
+  @Test
+  fun addSilenced_withoutOptionalArgs_stillWorks() {
+    accessManager.addSilenced(remoteIp.hostAddress, 10.minutes)
+    assertThat(accessManager.isSilenced(remoteIp)).isTrue()
+    val silence = accessManager.getSilence(remoteIp)
+    assertThat(silence!!.issuer).isNull()
+    assertThat(silence.reason).isNull()
+  }
+
+  // ── clearTemp tests ─────────────────────────────────────────────────────────
+
+  @Test
+  fun clearTemp_removesTempBan() {
+    accessManager.addTempBan(remoteIp.hostAddress, 10.minutes)
+    assertThat(accessManager.isAddressAllowed(remoteIp)).isFalse()
+
+    val cleared = accessManager.clearTemp(remoteIp, false)
+    assertThat(cleared).isTrue()
+    assertThat(accessManager.isAddressAllowed(remoteIp)).isTrue()
+  }
+
+  @Test
+  fun clearTemp_removesSilence() {
+    accessManager.addSilenced(remoteIp.hostAddress, 10.minutes)
+    assertThat(accessManager.isSilenced(remoteIp)).isTrue()
+
+    accessManager.clearTemp(remoteIp, false)
+    assertThat(accessManager.isSilenced(remoteIp)).isFalse()
+  }
+
+  @Test
+  fun clearTemp_returnsFalseWhenNothingToClear() {
+    assertThat(accessManager.clearTemp(remoteIp, false)).isFalse()
+  }
+
+  // ── addPermaBan tests ───────────────────────────────────────────────────────
+
+  @Test
+  fun addPermaBan_blocksAddress() {
+    assertThat(accessManager.isAddressAllowed(remoteIp)).isTrue()
+    accessManager.addPermaBan(remoteIp.hostAddress)
+    assertThat(accessManager.isAddressAllowed(remoteIp)).isFalse()
+  }
+
+  @Test
+  fun addPermaBan_writesIpDenyLineToFile() {
+    accessManager.addPermaBan(remoteIp.hostAddress, issuer = "Admin", reason = "Ban evasion")
+    val content = accessFile.readText()
+    assertThat(content).contains("ipaddress,DENY,${remoteIp.hostAddress}")
+  }
+
+  @Test
+  fun addPermaBan_writesIssuerCommentToFile() {
+    accessManager.addPermaBan(remoteIp.hostAddress, issuer = "Admin123", reason = null)
+    val content = accessFile.readText()
+    assertThat(content).contains("# Permanent ban issued by Admin123")
+  }
+
+  @Test
+  fun addPermaBan_writesReasonCommentToFile_whenProvided() {
+    accessManager.addPermaBan(remoteIp.hostAddress, issuer = "Admin", reason = "Cheating")
+    val content = accessFile.readText()
+    assertThat(content).contains("# Reason: Cheating")
+  }
+
+  @Test
+  fun addPermaBan_doesNotWriteReasonComment_whenNoReason() {
+    accessManager.addPermaBan(remoteIp.hostAddress, issuer = "Admin", reason = null)
+    val content = accessFile.readText()
+    assertThat(content).doesNotContain("# Reason:")
+  }
+
+  @Test
+  fun addPermaBan_doesNotBlockOtherAddresses() {
+    accessManager.addPermaBan(remoteIp.hostAddress)
+    assertThat(accessManager.isAddressAllowed(otherIp)).isTrue()
+  }
+
+  // ── addPermaMute tests ──────────────────────────────────────────────────────
+
+  @Test
+  fun addPermaMute_silencesAddress() {
+    assertThat(accessManager.isSilenced(remoteIp)).isFalse()
+    accessManager.addPermaMute(remoteIp.hostAddress)
+    assertThat(accessManager.isSilenced(remoteIp)).isTrue()
+  }
+
+  @Test
+  fun addPermaMute_writesSilenceLineToFile() {
+    accessManager.addPermaMute(remoteIp.hostAddress, issuer = "Admin", reason = null)
+    val content = accessFile.readText()
+    assertThat(content).contains("silence,${remoteIp.hostAddress}")
+  }
+
+  @Test
+  fun addPermaMute_writesIssuerCommentToFile() {
+    accessManager.addPermaMute(remoteIp.hostAddress, issuer = "Mod99", reason = null)
+    val content = accessFile.readText()
+    assertThat(content).contains("# Permanent silence issued by Mod99")
+  }
+
+  @Test
+  fun addPermaMute_writesReasonCommentToFile_whenProvided() {
+    accessManager.addPermaMute(remoteIp.hostAddress, issuer = "Admin", reason = "Hate speech")
+    val content = accessFile.readText()
+    assertThat(content).contains("# Reason: Hate speech")
+  }
+
+  @Test
+  fun addPermaMute_doesNotSilenceOtherAddresses() {
+    accessManager.addPermaMute(remoteIp.hostAddress)
+    assertThat(accessManager.isSilenced(otherIp)).isFalse()
+  }
+
+  // ── Static access config tests ──────────────────────────────────────────────
+
+  @Test
+  fun isAddressAllowed_defaultsToTrue() {
+    assertThat(accessManager.isAddressAllowed(remoteIp)).isTrue()
+  }
+
+  @Test
+  fun isAddressAllowed_returnsFalseForDeniedPattern() {
+    accessFile.writeText("ipaddress,DENY,${remoteIp.hostAddress}\nipaddress,ALLOW,*\n")
+    accessManager.forceReload()
+    assertThat(accessManager.isAddressAllowed(remoteIp)).isFalse()
+    assertThat(accessManager.isAddressAllowed(otherIp)).isTrue()
+  }
+
+  @Test
+  fun getAccess_returnsAdminForConfiguredSuperadmin() {
+    accessFile.writeText("user,SUPERADMIN,${localIp.hostAddress}\nipaddress,ALLOW,*\n")
+    accessManager.forceReload()
+    assertThat(accessManager.getAccess(localIp)).isEqualTo(AccessManager.ACCESS_SUPERADMIN)
+  }
+
+  @Test
+  fun getAccess_returnsNormalForUnknownAddress() {
+    assertThat(accessManager.getAccess(remoteIp)).isEqualTo(AccessManager.ACCESS_NORMAL)
+  }
+
+  fun AccessManager2.forceReload() {
+    val method = AccessManager2::class.java.getDeclaredMethod("loadAccess")
+    method.isAccessible = true
+    method.invoke(this)
+  }
+
+  companion object {
+    private fun buildFlags() =
+      RuntimeFlags(
+        allowMultipleConnections = true,
+        allowSinglePlayer = true,
+        charset = Charsets.UTF_8,
+        chatFloodTime = 0.milliseconds,
+        allowedProtocols = listOf("0.83"),
+        allowedConnectionTypes = listOf("1"),
+        coreThreadPoolSize = 4,
+        createGameFloodTime = 0.milliseconds,
+        gameAutoFireSensitivity = 0,
+        gameBufferSize = 12,
+        idleTimeout = 1.minutes,
+        keepAliveTimeout = 1.minutes,
+        lagstatDuration = 1.minutes,
+        language = "en",
+        maxChatLength = 256,
+        maxClientNameLength = 64,
+        maxGameChatLength = 256,
+        maxGameNameLength = 64,
+        maxGames = 100,
+        maxPing = 1000.milliseconds,
+        maxQuitMessageLength = 256,
+        maxUserNameLength = 31,
+        maxUsers = 100,
+        metricsEnabled = false,
+        metricsLoggingFrequency = 1.minutes,
+        serverAddress = "127.0.0.1",
+        serverLocation = "Test",
+        serverName = "Test Server",
+        serverPort = 27888,
+        serverWebsite = "",
+        switchStatusBytesForBuggyClient = false,
+        touchEmulinker = false,
+        touchKaillera = false,
+        twitterBroadcastDelay = 0.milliseconds,
+        twitterDeletePostOnClose = false,
+        twitterEnabled = false,
+        twitterOAuthAccessToken = "",
+        twitterOAuthAccessTokenSecret = "",
+        twitterOAuthConsumerKey = "",
+        twitterOAuthConsumerSecret = "",
+        twitterPreventBroadcastNameSuffixes = emptyList(),
+        v086BufferSize = 4096,
+      )
+  }
+}

--- a/emulinker/src/test/java/org/emulinker/kaillera/controller/GameChatE2ETest.kt
+++ b/emulinker/src/test/java/org/emulinker/kaillera/controller/GameChatE2ETest.kt
@@ -77,7 +77,12 @@ class GameChatE2ETest : KoinComponent {
 
     override fun getAnnouncement(address: InetAddress): String? = null
 
-    override fun addTempBan(addressPattern: String, duration: Duration) {}
+    override fun addTempBan(
+      addressPattern: String,
+      duration: Duration,
+      issuer: String?,
+      reason: String?,
+    ) {}
 
     override fun addTempAdmin(addressPattern: String, duration: Duration) {}
 
@@ -85,9 +90,22 @@ class GameChatE2ETest : KoinComponent {
 
     override fun addTempElevated(addressPattern: String, duration: Duration) {}
 
-    override fun addSilenced(addressPattern: String, duration: Duration) {}
+    override fun addSilenced(
+      addressPattern: String,
+      duration: Duration,
+      issuer: String?,
+      reason: String?,
+    ) {}
 
     override fun clearTemp(address: InetAddress, clearAll: Boolean): Boolean = false
+
+    override fun addPermaBan(addressPattern: String, issuer: String?, reason: String?) {}
+
+    override fun addPermaMute(addressPattern: String, issuer: String?, reason: String?) {}
+
+    override fun getTempBan(address: InetAddress): org.emulinker.kaillera.access.TempBan? = null
+
+    override fun getSilence(address: InetAddress): org.emulinker.kaillera.access.Silence? = null
 
     override fun close() {}
   }

--- a/emulinker/src/test/java/org/emulinker/kaillera/controller/GameDataE2ETest.kt
+++ b/emulinker/src/test/java/org/emulinker/kaillera/controller/GameDataE2ETest.kt
@@ -77,7 +77,12 @@ class GameDataE2ETest : KoinComponent {
 
     override fun getAnnouncement(address: InetAddress): String? = null
 
-    override fun addTempBan(addressPattern: String, duration: Duration) {}
+    override fun addTempBan(
+      addressPattern: String,
+      duration: Duration,
+      issuer: String?,
+      reason: String?,
+    ) {}
 
     override fun addTempAdmin(addressPattern: String, duration: Duration) {}
 
@@ -85,9 +90,22 @@ class GameDataE2ETest : KoinComponent {
 
     override fun addTempElevated(addressPattern: String, duration: Duration) {}
 
-    override fun addSilenced(addressPattern: String, duration: Duration) {}
+    override fun addSilenced(
+      addressPattern: String,
+      duration: Duration,
+      issuer: String?,
+      reason: String?,
+    ) {}
 
     override fun clearTemp(address: InetAddress, clearAll: Boolean): Boolean = false
+
+    override fun addPermaBan(addressPattern: String, issuer: String?, reason: String?) {}
+
+    override fun addPermaMute(addressPattern: String, issuer: String?, reason: String?) {}
+
+    override fun getTempBan(address: InetAddress): org.emulinker.kaillera.access.TempBan? = null
+
+    override fun getSilence(address: InetAddress): org.emulinker.kaillera.access.Silence? = null
 
     override fun close() {}
   }


### PR DESCRIPTION
- Add /permaban and /permamute commands to automatically persist to access.cfg
- Add /info command to view active restrictions and internal reasons
- Expand /clear to accept User IDs and Names
- Support optional hidden reasons for bans and mutes
- Add persistent tracking for rule issuers and reasons