### PR TITLE
Ask users a survey question related to lag

### DIFF
--- a/.agents/skills/emulinkerk-deploy-nue/SKILL.md
+++ b/.agents/skills/emulinkerk-deploy-nue/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: emulinkerk-deploy-nue
+description: >-
+  Builds, deploys, and restarts the EmuLinker-K server on the 'nue-prod' EC2
+  instance safely by checking the server status first.
+---
+
+# Deploy EmuLinker-K to nue-prod
+
+## Overview
+This skill guides the agent to safely build and deploy a new version of the EmuLinker-K server to the `nue-prod` instance. It ensures that the deployment doesn't interrupt active players by calling the server status skill before restarting.
+
+## Dependencies
+- **emulinkerk-server-status**: Used to inspect the remote server log and determine if there are active players or games.
+
+## Quick Start
+Run this skill to deploy the current local changes to `nue-prod`.
+
+## Workflow
+
+### 1. Build the local JAR
+Run the Gradle clean task and compile the fat JAR:
+```bash
+./gradlew clean :emulinker:jar -PprodBuild=true
+```
+Check the version in `emulinker/build.gradle.kts` (look for `version = "<VERSION>"`). The built jar is located at `./emulinker/build/libs/emulinker-k-<VERSION>.jar`.
+
+### 2. Copy the JAR to the remote server
+Generate a timestamp in `YYYYMMHH` format:
+```bash
+TIMESTAMP=$(date +%Y%m%H)
+```
+Copy the JAR to the remote server using `scp`, appending the timestamp and `-DEV`:
+```bash
+scp ./emulinker/build/libs/emulinker-k-<VERSION>.jar ec2-user@nue-prod:/home/ec2-user/EmuLinker-K/lib/emulinker-k-<VERSION>-${TIMESTAMP}-DEV.jar
+```
+
+### 3. Read and analyze remote logs
+Use the `emulinkerk-server-status` skill with:
+- **ssh-target**: `ec2-user@nue-prod`
+- **log-path**: `/home/ec2-user/EmuLinker-K/emulinker.log`
+
+Determine if the server is safe to restart:
+- If the status report shows 0 active games and 0 active users, proceed directly to **Step 5 (Restart Server)**.
+- If there are any active games or connected users, proceed to **Step 4 (Warn and Ask User)**.
+
+### 4. Warn and Ask User
+If the server is not empty, report the current active games and users to the user.
+* **Example**: "Warning: There is 1 active game (ID: 5) and 2 connected users on the server."
+* Prompt the user: "Do you want to proceed with restarting the server and disrupting these players?"
+* Wait for the user to explicitly reply "yes" before proceeding. If they say "no" or do not confirm, abort the deployment.
+
+### 5. Restart Server
+Restart the remote server in a combined SSH command:
+```bash
+ssh ec2-user@nue-prod "cd /home/ec2-user/EmuLinker-K && ./stop-server.sh && ./start-server.sh --jar ./lib/emulinker-k-<VERSION>-${TIMESTAMP}-DEV.jar"
+```
+Print the output returned by the script directly to verify successful boot.
+
+## Common Mistakes
+- **Restarting blindly**: Forgetting to check the server status first, resulting in booting active players.
+- **Incorrect JAR override flag**: Forgetting the `--jar` override when starting the server, which runs the old default production JAR instead of the newly deployed one.

--- a/.agents/skills/emulinkerk-server-status/SKILL.md
+++ b/.agents/skills/emulinkerk-server-status/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: emulinkerk-server-status
+description: >-
+  Inspects the remote EmuLinker-K server log file via SSH to determine the active
+  users, active games, and their current states.
+---
+
+# EmuLinker-K Server Status
+
+## Overview
+This skill allows the agent to inspect the state of a remote EmuLinker-K server by tailing and analyzing its log file over SSH. It extracts the baseline user and game counts from the last hourly status update and tracks subsequent logs to find the current active user count and active games.
+
+## Quick Start
+Provide the SSH connection string (e.g., `ec2-user@nue-prod`) and the absolute path to the log file (e.g., `/home/ec2-user/EmuLinker-K/emulinker.log`) to check the server's current state.
+
+## Workflow
+
+### 1. Fetch Remote Logs
+Run the following tail command, substituting `<ssh-target>` and `<log-path>` with the provided inputs:
+```bash
+ssh <ssh-target> "tail -n 200 <log-path>"
+```
+
+### 2. Locate the Baseline Update
+Scan backwards in the log lines to find the **last** line containing `[Hourly status update]`. It will look like:
+`2026-06-17 11:28:15,796 INFO o.e.k.m.KailleraServer [TaskScheduler] [Hourly status update] Game IDs by status = (no games), number of users = 0`
+
+* Note: If no hourly status update is found within the last 200 lines, run the tail command again with a larger limit (e.g., `1000` or `5000` lines) until the hourly update line is found.
+
+### 3. Establish Baseline State
+- **Baseline Games**:
+  - If `Game IDs by status = (no games)`, the baseline game set is empty `{}`.
+  - Otherwise (e.g. `Game IDs by status = {PLAYING=[10], WAITING=[12]}`), parse the game IDs into an active games set (e.g., `{10: "PLAYING", 12: "WAITING"}`).
+- **Baseline Users**:
+  - Parse `number of users = <N>`. This is the baseline user count.
+
+### 4. Process Chronological Deltas
+Scan all log lines that occurred *after* the baseline hourly status update from oldest to newest:
+- **Games**:
+  - If a line contains `created: Game[id=<ID> name=<NAME>]: <ROM>`, add the game to the active games set.
+  - If a line contains `closed game: Game[id=<ID>` or `game desynched: game closed!`, remove the game `<ID>` from the active games set.
+  - If a line contains `started: Game[id=<ID>`, update that game's status to `PLAYING`.
+- **Users**:
+  - If a line contains `User[id=<ID> name=<NAME>]: login request:`, add the user ID to the list of logged-in users.
+  - If a line contains `login denied:` or `quit server:` or `inactivity timeout!` or `banned!` or `disconnected from server` for a user, remove the user from the list of logged-in users.
+  - Keep track of the current number of users: `baseline_user_count + post_baseline_logins - post_baseline_disconnects`.
+
+### 5. Report Current Status
+Summarize the current state:
+- Number of active users (and their names, if any logged in after the baseline).
+- Number of active games.
+- For each active game: ID, name/ROM, and status (e.g., PLAYING or WAITING).

--- a/docs/survey.md
+++ b/docs/survey.md
@@ -1,0 +1,34 @@
+# Survey Feature Documentation
+
+The EmuLinker-K survey feature enables server administrators to periodically poll players about their connection quality and securely bundle this data with telemetry (GameLog proto) for analysis.
+
+## Workflow
+
+1. **Consent Request**
+   When players join or create a game, they are prompted via a server message asking if they'd like to participate in an academic survey mapping lag experiences. They must answer `"yes"` in chat to enroll. Non-responses or answers of `"no"` will automatically exclude them from the survey loop.
+
+2. **Wait Period**
+   Starting from the point the game status shifts to `PLAYING` (when all players synchronize and inputs begin processing), an 8-minute cooldown is initialized. No survey prompts will trigger during this time.
+
+3. **Intelligent Triggering**
+   Rather than interrupting gameplay randomly for everyone after 8 minutes, the server waits for a moment of downtime to issue the prompt. 
+   - After the 8-minute window finishes, anytime *any* player presses the **START** button on their controller (typically signaling a pause or break in the action), a check is performed. To minimize latency overhead, this bitmask verification against the raw game state (`ByteBuf`) only executes once every 3 frames per player.
+   - If a **START** button press is detected, the survey is immediately dispatched to *all* currently eligible players in the game (those who have consented and have not been surveyed in the last 10 minutes).
+
+4. **Telemetry Snapshot (5-Minute Rolling Window)**
+   To optimize memory use and ensure matching data records, the `GameLog` accumulator automatically culls telemetry entries exceeding 5 minutes old in real time. 
+   - Exactly when the survey prompt triggers, a snapshot of this 5-minute protocol log is created and cached locally in the game scope.
+   - This prevents memory overflow during long play sessions and makes certain that the telemetry represents the exact window of gameplay *before* the prompt appeared.
+
+5. **Response and Transmission**
+   Players have precisely 1.5 minutes to cast a response (ratings from `1` to `3`). If valid feedback is given within this timeframe:
+   - The system intercepts the answer in the game chat.
+   - It collates their rating alongside the snapshotted 5-minute proto log array.
+   - This data payload can then be serialized over the wire to an analytical backend server (`reportSurveyResponse` stub).
+
+## Technical Implementation
+
+- **`RuntimeFlags`**: Manages the `surveyEnabled` global toggle via configuration.
+- **`KailleraUser`**: Houses properties to handle boolean `surveyConsent` and explicit cooldown timeouts `lastSurveyAskedTimeNs`.
+- **`KailleraGame`**: Drives the logical matrix. Tracks individual and global timers, polls raw protocol data for matching start-button bitmasks `(data.getByte(index + 12) & 0x10)`, generates protocol log snapshots, and interfaces directly with the users' chat streams.
+- **I18n**: All prompting and system feedback text resolves through the established localization framework (`messages.properties` > `EmuLang`).

--- a/docs/survey.md
+++ b/docs/survey.md
@@ -4,23 +4,26 @@ The EmuLinker-K survey feature enables server administrators to periodically pol
 
 ## Workflow
 
-1. **Consent Request**
-   When players join or create a game, they are prompted via a server message asking if they'd like to participate in an academic survey mapping lag experiences. They must answer `"yes"` in chat to enroll. Non-responses or answers of `"no"` will automatically exclude them from the survey loop.
+1. **Game Eligibility**
+   Before the server prompts any players or tracks timing, it dynamically evaluates the game being played. The game's rom name must match at least one of the regex patterns specified in the administrator's `survey.gameWhitelist` configuration options. If none match (or if the whitelist is empty), the survey subsystem remains entirely dormant for that specific game.
 
-2. **Wait Period**
+2. **Consent Request**
+   When players join or create an eligible game, they are prompted via a server message asking if they'd like to participate in an academic survey mapping lag experiences. They must answer `"yes"` in chat *within exactly 4 minutes* of the prompt to successfully enroll. Non-responses or answers of `"no"` will permanently exclude them from the survey loop for the session.
+
+3. **Wait Period**
    Starting from the point the game status shifts to `PLAYING` (when all players synchronize and inputs begin processing), an 8-minute cooldown is initialized. No survey prompts will trigger during this time.
 
-3. **Intelligent Triggering**
+4. **Intelligent Triggering**
    Rather than interrupting gameplay randomly for everyone after 8 minutes, the server waits for a moment of downtime to issue the prompt. 
    - After the 8-minute window finishes, anytime *any* player presses the **START** button on their controller (typically signaling a pause or break in the action), a check is performed. To minimize latency overhead, this bitmask verification against the raw game state (`ByteBuf`) only executes once every 3 frames per player.
    - If a **START** button press is detected, the survey is immediately dispatched to *all* currently eligible players in the game (those who have consented and have not been surveyed in the last 10 minutes).
 
-4. **Telemetry Snapshot (5-Minute Rolling Window)**
+5. **Telemetry Snapshot (5-Minute Rolling Window)**
    To optimize memory use and ensure matching data records, the `GameLog` accumulator automatically culls telemetry entries exceeding 5 minutes old in real time. 
    - Exactly when the survey prompt triggers, a snapshot of this 5-minute protocol log is created and cached locally in the game scope.
    - This prevents memory overflow during long play sessions and makes certain that the telemetry represents the exact window of gameplay *before* the prompt appeared.
 
-5. **Response and Transmission**
+6. **Response and Transmission**
    Players have precisely 1.5 minutes to cast a response (ratings from `1` to `3`). If valid feedback is given within this timeframe:
    - The system intercepts the answer in the game chat.
    - It collates their rating alongside the snapshotted 5-minute proto log array.
@@ -28,7 +31,7 @@ The EmuLinker-K survey feature enables server administrators to periodically pol
 
 ## Technical Implementation
 
-- **`RuntimeFlags`**: Manages the `surveyEnabled` global toggle via configuration.
-- **`KailleraUser`**: Houses properties to handle boolean `surveyConsent` and explicit cooldown timeouts `lastSurveyAskedTimeNs`.
+- **`RuntimeFlags`**: Manages the `surveyEnabled` global toggle and `surveyGameWhitelist` array via configuration.
+- **`KailleraUser`**: Houses properties to handle boolean `surveyConsent` and internal `TimeMark` cooldown mechanisms explicitly handling consent wait times (`surveyConsentAskedTimeMark`) and answer timeouts (`lastSurveyAskedTimeMark`).
 - **`KailleraGame`**: Drives the logical matrix. Tracks individual and global timers, polls raw protocol data for matching start-button bitmasks `(data.getByte(index + 12) & 0x10)`, generates protocol log snapshots, and interfaces directly with the users' chat streams.
 - **I18n**: All prompting and system feedback text resolves through the established localization framework (`messages.properties` > `EmuLang`).

--- a/emulinker/src/main/i18n/messages.properties
+++ b/emulinker/src/main/i18n/messages.properties
@@ -190,3 +190,10 @@ Time.MinutesAbbreviation={0}m
 
 ! Notifies the user that the server will now start measuring lag at a new frame rate.
 Fps.NewFpsMeasurement=Measuring lag for {0,number,integer} frames per second
+
+# Survey
+Survey.Consent=You are invited to take part in an academic research study. If you agree to participate, you will periodically receive short questions about your experience. For more information about the study see https://sites.gsu.edu/rjeter/lag.\n\nDo you agree to participate and confirm you are of age (a legal adult) in your country of residence? Answer “yes” to participate.
+Survey.Question=Over the last {0} minutes, how would you describe lag during the game:\n(1) None\n(2) Noticeable, but playable\n(3) Unplayable\nRespond with the number corresponding to your answer.
+Survey.ConsentYes=Thank you for participating\! We will ask you a question later.
+Survey.ConsentNo=Understood. You will not be asked any survey questions.
+Survey.Thanks=Thank you for your feedback\!

--- a/emulinker/src/main/java/org/emulinker/config/RuntimeFlags.kt
+++ b/emulinker/src/main/java/org/emulinker/config/RuntimeFlags.kt
@@ -49,6 +49,7 @@ data class RuntimeFlags(
   val twitterOAuthConsumerSecret: String,
   val twitterPreventBroadcastNameSuffixes: List<String>,
   val v086BufferSize: Int,
+  val surveyEnabled: Boolean,
 ) {
 
   init {

--- a/emulinker/src/main/java/org/emulinker/config/RuntimeFlags.kt
+++ b/emulinker/src/main/java/org/emulinker/config/RuntimeFlags.kt
@@ -50,6 +50,7 @@ data class RuntimeFlags(
   val twitterPreventBroadcastNameSuffixes: List<String>,
   val v086BufferSize: Int,
   val surveyEnabled: Boolean,
+  val surveyGameWhitelist: List<String>,
 ) {
 
   init {

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameChatAction.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/v086/action/GameChatAction.kt
@@ -25,7 +25,6 @@ import org.emulinker.kaillera.model.KailleraGame
 import org.emulinker.kaillera.model.event.GameChatEvent
 import org.emulinker.kaillera.model.exception.ActionException
 import org.emulinker.kaillera.model.exception.GameChatException
-import org.emulinker.proto.GameLog
 import org.emulinker.util.EmuLang
 import org.emulinker.util.EmuLang.getStringOrNull
 import org.emulinker.util.EmuUtil.min
@@ -531,15 +530,6 @@ class GameChatAction(
         val newFps = message.message.removePrefix("/fps ").toDouble()
         game.setGameFps(newFps)
         game.announce(EmuLang.getString("Fps.NewFpsMeasurement", newFps))
-      } else if (
-        clientHandler.user.accessLevel >= AccessManager.ACCESS_ADMIN &&
-          message.message.trim() == "/loggame"
-      ) {
-        game.chat(clientHandler.user, message.message)
-        if (game.gameLogBuilder == null) {
-          game.gameLogBuilder = GameLog.newBuilder()
-          game.announce("Enabled logging for session.")
-        }
       } else {
         game.announce(
           EmuLang.getString("ChatAction.UnrecognizedCommand", message.message),

--- a/emulinker/src/main/java/org/emulinker/kaillera/model/KailleraGame.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/model/KailleraGame.kt
@@ -1,7 +1,6 @@
 package org.emulinker.kaillera.model
 
 import com.google.common.flogger.FluentLogger
-import com.google.protobuf.util.Timestamps
 import io.netty.buffer.ByteBuf
 import io.netty.buffer.PooledByteBufAllocator
 import java.util.Date
@@ -11,8 +10,6 @@ import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.nanoseconds
 import kotlin.time.Duration.Companion.seconds
-import kotlin.time.TimeMark
-import kotlin.time.TimeSource
 import org.emulinker.config.RuntimeFlags
 import org.emulinker.kaillera.access.AccessManager
 import org.emulinker.kaillera.master.StatsCollector
@@ -38,19 +35,15 @@ import org.emulinker.kaillera.model.exception.StartGameException
 import org.emulinker.kaillera.model.exception.UserReadyException
 import org.emulinker.kaillera.model.impl.AutoFireDetector
 import org.emulinker.kaillera.model.impl.PlayerActionQueue
-import org.emulinker.proto.EventKt.GameStartKt.playerDetails
+import org.emulinker.proto.Event.LagstatSummary
 import org.emulinker.proto.EventKt.LagstatSummaryKt.playerAttributedLag
-import org.emulinker.proto.EventKt.fanOut
-import org.emulinker.proto.EventKt.gameStart
 import org.emulinker.proto.EventKt.lagstatSummary
-import org.emulinker.proto.EventKt.receivedGameData
 import org.emulinker.proto.GameLog
 import org.emulinker.proto.Player
 import org.emulinker.proto.Player.PLAYER_FOUR
 import org.emulinker.proto.Player.PLAYER_ONE
 import org.emulinker.proto.Player.PLAYER_THREE
 import org.emulinker.proto.Player.PLAYER_TWO
-import org.emulinker.proto.event
 import org.emulinker.util.EmuLang
 import org.emulinker.util.EmuUtil.toMillisDouble
 import org.koin.core.component.KoinComponent
@@ -133,11 +126,7 @@ class KailleraGame(
   var aEmulator = "any"
   var aConnection = "any"
   val startDate: Date = Date()
-  private var gameStartTimeMark: TimeMark? = null
-  private var pendingSurveyGameLog: ByteArray? = null
-
-  val isSurveyEligibleForGame =
-    flags.surveyEnabled && flags.surveyGameWhitelist.any { Regex(it).containsMatchIn(romName) }
+  val surveyManager = SurveyManager(this)
 
   @JvmField var swap = false
 
@@ -221,13 +210,7 @@ class KailleraGame(
 
     addEventForAllPlayers(GameChatEvent(this, user, message))
 
-    if (isSurveyEligibleForGame) {
-      when (user.surveyConsent) {
-        null -> handleSurveyConsent(user, message)
-        true -> handleSurveyResponse(user, message)
-        false -> {}
-      }
-    }
+    surveyManager.handleChat(user, message)
   }
 
   fun announce(announcement: String, toUser: KailleraUser? = null) {
@@ -370,10 +353,7 @@ class KailleraGame(
         GameInfoEvent(this, user.name + " using different emulator version: " + user.clientType)
       )
 
-    if (isSurveyEligibleForGame && user.surveyConsent == null) {
-      announce(EmuLang.getString("Survey.Consent"), user)
-      user.surveyConsentAskedTimeMark = TimeSource.Monotonic.markNow()
-    }
+    surveyManager.onUserJoined(user)
 
     return players.indexOf(user) + 1
   }
@@ -450,7 +430,7 @@ class KailleraGame(
     }
     logger.atInfo().log("%s started: %s", user, this)
     status = GameStatus.SYNCHRONIZING
-    gameStartTimeMark = TimeSource.Monotonic.markNow()
+    surveyManager.onGameStarted()
     autoFireDetector.start(players.size)
     val actionQueueBuilder = mutableListOf<PlayerActionQueue>()
 
@@ -489,23 +469,6 @@ class KailleraGame(
     }
     playerActionQueues = actionQueueBuilder.toTypedArray()
     statsCollector?.markGameAsStarted(server, this)
-    gameLogBuilder?.addEvents(
-      event {
-        timestampNs = System.nanoTime()
-        gameStart = gameStart {
-          timestamp = Timestamps.now()
-          for (player in this@KailleraGame.players) {
-            this@gameStart.players += playerDetails {
-              playerNumber = player.playerNumber.toPlayerNumberProto()
-
-              frameDelay = player.frameDelay
-              pingMs = player.ping.toMillisDouble()
-            }
-          }
-        }
-      }
-    )
-
     /*if(user.getConnectionType() > KailleraUser.CONNECTION_TYPE_GOOD || user.getConnectionType() < KailleraUser.CONNECTION_TYPE_GOOD){
     	//sameDelay = true;
     }*/
@@ -717,113 +680,18 @@ class KailleraGame(
       return AddDataResult.IgnoringDesynched
     }
 
-    gameLogBuilder?.addEvents(
-      event {
-        timestampNs =
-          checkNotNull(lagometer?.userDatas[user.playerNumber - 1]?.receivedDataNs) {
-            "user's receivedGameDataNs is null!"
-          }
-        receivedGameData =
-          when (user.playerNumber) {
-            1 -> RECEIVED_FROM_P1
-            2 -> RECEIVED_FROM_P2
-            3 -> RECEIVED_FROM_P3
-            4 -> RECEIVED_FROM_P4
-            else -> throw IllegalStateException("Player number is out of bounds!")
-          }
-      }
+    surveyManager.logReceivedGameData(
+      playerNumber = user.playerNumber,
+      timestampNs = lagometer?.userDatas?.get(user.playerNumber - 1)?.receivedDataNs,
     )
 
     // Add the data for the user to their own player queue.
     playerActionQueues?.get(playerNumber - 1)?.addActions(data)
     autoFireDetector.addData(playerNumber, data, user.bytesPerAction)
 
-    // As we handle incoming controller inputs, check every three frames if a user pressed start. If
-    // they did, trigger the survey for all users who consented.
-    if (isSurveyEligibleForGame && status == GameStatus.PLAYING && user.frameCount % 3 == 0) {
-      val gameStart = gameStartTimeMark
-      if (gameStart != null && gameStart.elapsedNow() > SURVEY_GAME_START_DELAY) {
-        val eligiblePlayers =
-          players.filter { p ->
-            val lastAsked = p.lastSurveyAskedTimeMark
-            p.surveyConsent == true &&
-              (lastAsked == null || lastAsked.elapsedNow() > SURVEY_COOLDOWN)
-          }
-        if (eligiblePlayers.isNotEmpty()) {
-          if (checkStartPressed(data, user.bytesPerAction)) {
-            // Snapshot the rolling 5-minute window.
-            val nowNs = System.nanoTime()
-            val fiveMinsAgoNs = nowNs - 5.minutes.inWholeNanoseconds
-            val recentEvents =
-              gameLogBuilder?.eventsList?.filter { it.timestampNs >= fiveMinsAgoNs }
-            val snapshotBuilder = GameLog.newBuilder()
-            if (recentEvents != null) {
-              snapshotBuilder.addAllEvents(recentEvents)
-            }
-            pendingSurveyGameLog = snapshotBuilder.build().toByteArray()
-
-            for (player in eligiblePlayers) {
-              askSurveyQuestion(player)
-              player.lastSurveyAskedTimeMark = TimeSource.Monotonic.markNow()
-            }
-          }
-        }
-      }
-    }
+    surveyManager.onControllerInput(user, data, user.bytesPerAction)
 
     return maybeSendData(user)
-  }
-
-  private fun checkStartPressed(data: ByteBuf, bytesPerAction: Int): Boolean {
-    if (data.readableBytes() < 13) return false
-    return (data.getByte(data.readerIndex() + 12).toInt() and 0b00010000) != 0
-  }
-
-  private fun askSurveyQuestion(player: KailleraUser) {
-    announce("SURVEY: ${EmuLang.getString("Survey.Question", "10")}", player)
-  }
-
-  private fun reportSurveyResponse(user: KailleraUser, response: String) {
-    val surveyLog = pendingSurveyGameLog
-    logger
-      .atInfo()
-      .log(
-        "Reporting survey response for %s: %s (Proto data size: %d)",
-        user.name,
-        response,
-        surveyLog?.size ?: 0,
-      )
-    // TODO: Send response and surveyLog to a server for analysis.
-  }
-
-  private fun handleSurveyConsent(user: KailleraUser, message: String) {
-    val askedTime = user.surveyConsentAskedTimeMark
-    if (askedTime == null || askedTime.elapsedNow() > SURVEY_CONSENT_TIMEOUT) return
-
-    when (message.lowercase()) {
-      "y",
-      "yes" -> {
-        user.surveyConsent = true
-        announce(EmuLang.getString("Survey.ConsentYes"), user)
-      }
-
-      "n",
-      "no" -> {
-        user.surveyConsent = false
-        announce(EmuLang.getString("Survey.ConsentNo"), user)
-      }
-    }
-  }
-
-  /** Handle user's message as a survey response. */
-  private fun handleSurveyResponse(user: KailleraUser, message: String) {
-    if (message.trim().matches("[1-3]".toRegex())) {
-      val lastAsked = user.lastSurveyAskedTimeMark
-      if (lastAsked != null && lastAsked.elapsedNow() <= MAX_SURVEY_RESPONSE_TIME) {
-        reportSurveyResponse(user, message.trim())
-        announce(EmuLang.getString("Survey.Thanks"), user)
-      }
-    }
   }
 
   /**
@@ -919,47 +787,28 @@ class KailleraGame(
     get() = lagometer?.lag ?: Duration.ZERO
 
   private fun updateGameDrift(nowNs: Long) {
-    val glb = gameLogBuilder
-    if (glb != null) {
-      glb.addEvents(
-        event {
-          timestampNs = nowNs
-          fanOut = FAN_OUT
-        }
-      )
+    var lagstatSummaryData: LagstatSummary? = null
 
-      // Log the /lagstat data once every 1 minute.
-      if ((nowNs - lastLagstatNs).nanoseconds > 1.minutes) {
-        glb.addEvents(
-          event {
-            timestampNs = nowNs
-            lagstatSummary = lagstatSummary {
-              windowDurationMs = flags.lagstatDuration.inWholeMilliseconds.toInt()
-              gameLagMs = currentGameLag.toMillisDouble()
+    // Log the /lagstat data once every 1 minute.
+    if ((nowNs - lastLagstatNs).nanoseconds > 1.minutes) {
+      lagstatSummaryData = lagstatSummary {
+        windowDurationMs = flags.lagstatDuration.inWholeMilliseconds.toInt()
+        gameLagMs = currentGameLag.toMillisDouble()
 
-              val lags = lagometer?.gameLagPerPlayer
-              if (lags != null) {
-                for ((i, p) in players.withIndex()) {
-                  playerAttributedLags += playerAttributedLag {
-                    player = p.playerNumber.toPlayerNumberProto()
-                    attributedLagMs = lags[i].toMillisDouble()
-                  }
-                }
-              }
+        val lags = lagometer?.gameLagPerPlayer
+        if (lags != null) {
+          for ((i, p) in players.withIndex()) {
+            playerAttributedLags += playerAttributedLag {
+              player = p.playerNumber.toPlayerNumberProto()
+              attributedLagMs = lags[i].toMillisDouble()
             }
           }
-        )
-        lastLagstatNs = nowNs
-
-        // Prune the game log to a 5-minute rolling window to prevent unbounded memory growth.
-        val fiveMinsAgoNs = nowNs - 5.minutes.inWholeNanoseconds
-        val recentEvents = glb.eventsList.takeLastWhile { it.timestampNs >= fiveMinsAgoNs }
-        if (recentEvents.size < glb.eventsCount) {
-          glb.clearEvents()
-          glb.addAllEvents(recentEvents)
         }
       }
+      lastLagstatNs = nowNs
     }
+
+    surveyManager.updateDrift(nowNs, lagstatSummaryData)
 
     lagometer?.advanceFrame(nowNs)
 
@@ -969,20 +818,7 @@ class KailleraGame(
   companion object {
     private val logger = FluentLogger.forEnclosingClass()
 
-    private val SURVEY_CONSENT_TIMEOUT = 4.minutes
-    private val MAX_SURVEY_RESPONSE_TIME = 1.5.minutes
-    private val SURVEY_GAME_START_DELAY = 8.minutes
-    private val SURVEY_COOLDOWN = 10.minutes
-
-    /** Unfortunately Kaillera is built on the assumption that all games run at 60FPS. */
     const val GAME_FPS = 60
-
-    // A few logging constants to avoid creating unnecessary objects.
-    private val FAN_OUT = fanOut {}
-    private val RECEIVED_FROM_P1 = receivedGameData { receivedFrom = PLAYER_ONE }
-    private val RECEIVED_FROM_P2 = receivedGameData { receivedFrom = PLAYER_TWO }
-    private val RECEIVED_FROM_P3 = receivedGameData { receivedFrom = PLAYER_THREE }
-    private val RECEIVED_FROM_P4 = receivedGameData { receivedFrom = PLAYER_FOUR }
 
     private fun Int.toPlayerNumberProto(): Player =
       when (this) {

--- a/emulinker/src/main/java/org/emulinker/kaillera/model/KailleraGame.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/model/KailleraGame.kt
@@ -261,6 +261,7 @@ class KailleraGame(
   @Throws(JoinGameException::class)
   fun join(user: KailleraUser): Int {
     val access = server.accessManager.getAccess(user.socketAddress!!.address)
+    user.surveyConsent = null
 
     // SF MOD - Join room spam protection
     if (lastAddress == user.connectSocketAddress.address.hostAddress) {
@@ -348,10 +349,11 @@ class KailleraGame(
       access < AccessManager.ACCESS_ADMIN &&
         user.clientType != owner.clientType &&
         !owner.game!!.romName.startsWith("*")
-    )
+    ) {
       addEventForAllPlayers(
         GameInfoEvent(this, user.name + " using different emulator version: " + user.clientType)
       )
+    }
 
     surveyManager.onUserJoined(user)
 

--- a/emulinker/src/main/java/org/emulinker/kaillera/model/KailleraGame.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/model/KailleraGame.kt
@@ -134,6 +134,7 @@ class KailleraGame(
   var aEmulator = "any"
   var aConnection = "any"
   val startDate: Date = Date()
+  private var gameStartTimeNs: Long = 0L
 
   @JvmField var swap = false
 
@@ -216,6 +217,27 @@ class KailleraGame(
     l.log("%s, %s gamechat: %s", user, this, message)
 
     addEventForAllPlayers(GameChatEvent(this, user, message))
+
+    if (flags.surveyEnabled) {
+      if (user.surveyConsent == null) {
+        val lowerMessage = message.lowercase()
+        if (lowerMessage == "y" || lowerMessage == "yes") {
+          user.surveyConsent = true
+          announce(EmuLang.getString("Survey.ConsentYes"), user)
+        } else if (lowerMessage == "n" || lowerMessage == "no") {
+          user.surveyConsent = false
+          announce(EmuLang.getString("Survey.ConsentNo"), user)
+        }
+      } else if (user.surveyConsent == true) {
+        // If the user has consented, check if this message is a survey response.
+        if (message.trim().matches(Regex("[1-3]"))) {
+          if (System.nanoTime() - user.lastSurveyAskedTimeNs <= 1.5.minutes.inWholeNanoseconds) {
+            reportSurveyResponse(user, message.trim())
+            announce(EmuLang.getString("Survey.Thanks"), user)
+          }
+        }
+      }
+    }
   }
 
   fun announce(announcement: String, toUser: KailleraUser? = null) {
@@ -357,6 +379,11 @@ class KailleraGame(
       addEventForAllPlayers(
         GameInfoEvent(this, user.name + " using different emulator version: " + user.clientType)
       )
+
+    if (flags.surveyEnabled && user.surveyConsent == null) {
+      announce(EmuLang.getString("Survey.Consent"), user)
+    }
+
     return players.indexOf(user) + 1
   }
 
@@ -432,6 +459,7 @@ class KailleraGame(
     }
     logger.atInfo().log("%s started: %s", user, this)
     status = GameStatus.SYNCHRONIZING
+    gameStartTimeNs = System.nanoTime()
     autoFireDetector.start(players.size)
     val actionQueueBuilder = mutableListOf<PlayerActionQueue>()
 
@@ -735,7 +763,44 @@ class KailleraGame(
     playerActionQueues?.get(playerNumber - 1)?.addActions(data)
     autoFireDetector.addData(playerNumber, data, user.bytesPerAction)
 
+    if (flags.surveyEnabled && status == GameStatus.PLAYING && user.surveyConsent == true) {
+      val nowNs = System.nanoTime()
+      if (nowNs - gameStartTimeNs > 8.minutes.inWholeNanoseconds) {
+        if (nowNs - user.lastSurveyAskedTimeNs > 10.minutes.inWholeNanoseconds) {
+          if (user.frameCount % 3 == 0) {
+            if (checkStartPressed(data, user.bytesPerAction)) {
+              askSurveyQuestion(user)
+              user.lastSurveyAskedTimeNs = nowNs
+            }
+          }
+        }
+      }
+    }
+
     return maybeSendData(user)
+  }
+
+  private fun checkStartPressed(data: ByteBuf, bytesPerAction: Int): Boolean {
+    if (data.readableBytes() < 13) return false
+    return (data.getByte(data.readerIndex() + 12).toInt() and 0b00010000) != 0
+  }
+
+  private fun askSurveyQuestion(player: KailleraUser) {
+    val question = EmuLang.getString("Survey.Question", "10")
+    announce("SURVEY: $question", player)
+  }
+
+  private fun reportSurveyResponse(user: KailleraUser, response: String) {
+    val gameLog = gameLogBuilder?.build()?.toByteArray()
+    logger
+      .atInfo()
+      .log(
+        "Reporting survey response for %s: %s (Proto data size: %d)",
+        user.name,
+        response,
+        gameLog?.size ?: 0,
+      )
+    // TODO: Send response and gameLog to a server for analysis.
   }
 
   /**

--- a/emulinker/src/main/java/org/emulinker/kaillera/model/KailleraGame.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/model/KailleraGame.kt
@@ -222,27 +222,10 @@ class KailleraGame(
     addEventForAllPlayers(GameChatEvent(this, user, message))
 
     if (isSurveyEligibleForGame) {
-      if (user.surveyConsent == null) {
-        val askedTime = user.surveyConsentAskedTimeMark
-        if (askedTime == null || askedTime.elapsedNow() <= SURVEY_CONSENT_TIMEOUT) {
-          val lowerMessage = message.lowercase()
-          if (lowerMessage == "y" || lowerMessage == "yes") {
-            user.surveyConsent = true
-            announce(EmuLang.getString("Survey.ConsentYes"), user)
-          } else if (lowerMessage == "n" || lowerMessage == "no") {
-            user.surveyConsent = false
-            announce(EmuLang.getString("Survey.ConsentNo"), user)
-          }
-        }
-      } else if (user.surveyConsent == true) {
-        // If the user has consented, check if this message is a survey response.
-        if (message.trim().matches(Regex("[1-3]"))) {
-          val lastAsked = user.lastSurveyAskedTimeMark
-          if (lastAsked != null && lastAsked.elapsedNow() <= MAX_SURVEY_RESPONSE_TIME) {
-            reportSurveyResponse(user, message.trim())
-            announce(EmuLang.getString("Survey.Thanks"), user)
-          }
-        }
+      when (user.surveyConsent) {
+        null -> handleSurveyConsent(user, message)
+        true -> handleSurveyResponse(user, message)
+        false -> {}
       }
     }
   }
@@ -755,18 +738,20 @@ class KailleraGame(
     playerActionQueues?.get(playerNumber - 1)?.addActions(data)
     autoFireDetector.addData(playerNumber, data, user.bytesPerAction)
 
-    if (isSurveyEligibleForGame && status == GameStatus.PLAYING) {
+    // As we handle incoming controller inputs, check every three frames if a user pressed start. If
+    // they did, trigger the survey for all users who consented.
+    if (isSurveyEligibleForGame && status == GameStatus.PLAYING && user.frameCount % 3 == 0) {
       val gameStart = gameStartTimeMark
       if (gameStart != null && gameStart.elapsedNow() > SURVEY_GAME_START_DELAY) {
         val eligiblePlayers =
-          players.filter {
-            it.surveyConsent == true &&
-              (it.lastSurveyAskedTimeMark == null ||
-                it.lastSurveyAskedTimeMark!!.elapsedNow() > SURVEY_COOLDOWN)
+          players.filter { p ->
+            val lastAsked = p.lastSurveyAskedTimeMark
+            p.surveyConsent == true &&
+              (lastAsked == null || lastAsked.elapsedNow() > SURVEY_COOLDOWN)
           }
-        if (eligiblePlayers.isNotEmpty() && user.frameCount % 3 == 0) {
+        if (eligiblePlayers.isNotEmpty()) {
           if (checkStartPressed(data, user.bytesPerAction)) {
-            // Snapshot the rolling 5-minute window
+            // Snapshot the rolling 5-minute window.
             val nowNs = System.nanoTime()
             val fiveMinsAgoNs = nowNs - 5.minutes.inWholeNanoseconds
             val recentEvents =
@@ -809,6 +794,36 @@ class KailleraGame(
         surveyLog?.size ?: 0,
       )
     // TODO: Send response and surveyLog to a server for analysis.
+  }
+
+  private fun handleSurveyConsent(user: KailleraUser, message: String) {
+    val askedTime = user.surveyConsentAskedTimeMark
+    if (askedTime == null || askedTime.elapsedNow() > SURVEY_CONSENT_TIMEOUT) return
+
+    when (message.lowercase()) {
+      "y",
+      "yes" -> {
+        user.surveyConsent = true
+        announce(EmuLang.getString("Survey.ConsentYes"), user)
+      }
+
+      "n",
+      "no" -> {
+        user.surveyConsent = false
+        announce(EmuLang.getString("Survey.ConsentNo"), user)
+      }
+    }
+  }
+
+  /** Handle user's message as a survey response. */
+  private fun handleSurveyResponse(user: KailleraUser, message: String) {
+    if (message.trim().matches("[1-3]".toRegex())) {
+      val lastAsked = user.lastSurveyAskedTimeMark
+      if (lastAsked != null && lastAsked.elapsedNow() <= MAX_SURVEY_RESPONSE_TIME) {
+        reportSurveyResponse(user, message.trim())
+        announce(EmuLang.getString("Survey.Thanks"), user)
+      }
+    }
   }
 
   /**

--- a/emulinker/src/main/java/org/emulinker/kaillera/model/KailleraGame.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/model/KailleraGame.kt
@@ -11,6 +11,8 @@ import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.nanoseconds
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeMark
+import kotlin.time.TimeSource
 import org.emulinker.config.RuntimeFlags
 import org.emulinker.kaillera.access.AccessManager
 import org.emulinker.kaillera.master.StatsCollector
@@ -131,7 +133,7 @@ class KailleraGame(
   var aEmulator = "any"
   var aConnection = "any"
   val startDate: Date = Date()
-  private var gameStartTimeNs: Long = 0L
+  private var gameStartTimeMark: TimeMark? = null
   private var pendingSurveyGameLog: ByteArray? = null
 
   @JvmField var swap = false
@@ -218,18 +220,22 @@ class KailleraGame(
 
     if (flags.surveyEnabled) {
       if (user.surveyConsent == null) {
-        val lowerMessage = message.lowercase()
-        if (lowerMessage == "y" || lowerMessage == "yes") {
-          user.surveyConsent = true
-          announce(EmuLang.getString("Survey.ConsentYes"), user)
-        } else if (lowerMessage == "n" || lowerMessage == "no") {
-          user.surveyConsent = false
-          announce(EmuLang.getString("Survey.ConsentNo"), user)
+        val askedTime = user.surveyConsentAskedTimeMark
+        if (askedTime == null || askedTime.elapsedNow() <= SURVEY_CONSENT_TIMEOUT) {
+          val lowerMessage = message.lowercase()
+          if (lowerMessage == "y" || lowerMessage == "yes") {
+            user.surveyConsent = true
+            announce(EmuLang.getString("Survey.ConsentYes"), user)
+          } else if (lowerMessage == "n" || lowerMessage == "no") {
+            user.surveyConsent = false
+            announce(EmuLang.getString("Survey.ConsentNo"), user)
+          }
         }
       } else if (user.surveyConsent == true) {
         // If the user has consented, check if this message is a survey response.
         if (message.trim().matches(Regex("[1-3]"))) {
-          if (System.nanoTime() - user.lastSurveyAskedTimeNs <= 1.5.minutes.inWholeNanoseconds) {
+          val lastAsked = user.lastSurveyAskedTimeMark
+          if (lastAsked != null && lastAsked.elapsedNow() <= MAX_SURVEY_RESPONSE_TIME) {
             reportSurveyResponse(user, message.trim())
             announce(EmuLang.getString("Survey.Thanks"), user)
           }
@@ -380,6 +386,7 @@ class KailleraGame(
 
     if (flags.surveyEnabled && user.surveyConsent == null) {
       announce(EmuLang.getString("Survey.Consent"), user)
+      user.surveyConsentAskedTimeMark = TimeSource.Monotonic.markNow()
     }
 
     return players.indexOf(user) + 1
@@ -457,7 +464,7 @@ class KailleraGame(
     }
     logger.atInfo().log("%s started: %s", user, this)
     status = GameStatus.SYNCHRONIZING
-    gameStartTimeNs = System.nanoTime()
+    gameStartTimeMark = TimeSource.Monotonic.markNow()
     autoFireDetector.start(players.size)
     val actionQueueBuilder = mutableListOf<PlayerActionQueue>()
 
@@ -746,16 +753,18 @@ class KailleraGame(
     autoFireDetector.addData(playerNumber, data, user.bytesPerAction)
 
     if (flags.surveyEnabled && status == GameStatus.PLAYING) {
-      val nowNs = System.nanoTime()
-      if (nowNs - gameStartTimeNs > 8.minutes.inWholeNanoseconds) {
+      val gameStart = gameStartTimeMark
+      if (gameStart != null && gameStart.elapsedNow() > SURVEY_GAME_START_DELAY) {
         val eligiblePlayers =
           players.filter {
             it.surveyConsent == true &&
-              (nowNs - it.lastSurveyAskedTimeNs) > 10.minutes.inWholeNanoseconds
+              (it.lastSurveyAskedTimeMark == null ||
+                it.lastSurveyAskedTimeMark!!.elapsedNow() > SURVEY_COOLDOWN)
           }
         if (eligiblePlayers.isNotEmpty() && user.frameCount % 3 == 0) {
           if (checkStartPressed(data, user.bytesPerAction)) {
             // Snapshot the rolling 5-minute window
+            val nowNs = System.nanoTime()
             val fiveMinsAgoNs = nowNs - 5.minutes.inWholeNanoseconds
             val recentEvents =
               gameLogBuilder?.eventsList?.filter { it.timestampNs >= fiveMinsAgoNs }
@@ -767,7 +776,7 @@ class KailleraGame(
 
             for (player in eligiblePlayers) {
               askSurveyQuestion(player)
-              player.lastSurveyAskedTimeNs = nowNs
+              player.lastSurveyAskedTimeMark = TimeSource.Monotonic.markNow()
             }
           }
         }
@@ -941,6 +950,11 @@ class KailleraGame(
 
   companion object {
     private val logger = FluentLogger.forEnclosingClass()
+
+    private val SURVEY_CONSENT_TIMEOUT = 4.minutes
+    private val MAX_SURVEY_RESPONSE_TIME = 1.5.minutes
+    private val SURVEY_GAME_START_DELAY = 8.minutes
+    private val SURVEY_COOLDOWN = 10.minutes
 
     /** Unfortunately Kaillera is built on the assumption that all games run at 60FPS. */
     const val GAME_FPS = 60

--- a/emulinker/src/main/java/org/emulinker/kaillera/model/KailleraGame.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/model/KailleraGame.kt
@@ -136,6 +136,9 @@ class KailleraGame(
   private var gameStartTimeMark: TimeMark? = null
   private var pendingSurveyGameLog: ByteArray? = null
 
+  val isSurveyEligibleForGame =
+    flags.surveyEnabled && flags.surveyGameWhitelist.any { Regex(it).containsMatchIn(romName) }
+
   @JvmField var swap = false
 
   var status = GameStatus.WAITING
@@ -218,7 +221,7 @@ class KailleraGame(
 
     addEventForAllPlayers(GameChatEvent(this, user, message))
 
-    if (flags.surveyEnabled) {
+    if (isSurveyEligibleForGame) {
       if (user.surveyConsent == null) {
         val askedTime = user.surveyConsentAskedTimeMark
         if (askedTime == null || askedTime.elapsedNow() <= SURVEY_CONSENT_TIMEOUT) {
@@ -384,7 +387,7 @@ class KailleraGame(
         GameInfoEvent(this, user.name + " using different emulator version: " + user.clientType)
       )
 
-    if (flags.surveyEnabled && user.surveyConsent == null) {
+    if (isSurveyEligibleForGame && user.surveyConsent == null) {
       announce(EmuLang.getString("Survey.Consent"), user)
       user.surveyConsentAskedTimeMark = TimeSource.Monotonic.markNow()
     }
@@ -752,7 +755,7 @@ class KailleraGame(
     playerActionQueues?.get(playerNumber - 1)?.addActions(data)
     autoFireDetector.addData(playerNumber, data, user.bytesPerAction)
 
-    if (flags.surveyEnabled && status == GameStatus.PLAYING) {
+    if (isSurveyEligibleForGame && status == GameStatus.PLAYING) {
       val gameStart = gameStartTimeMark
       if (gameStart != null && gameStart.elapsedNow() > SURVEY_GAME_START_DELAY) {
         val eligiblePlayers =

--- a/emulinker/src/main/java/org/emulinker/kaillera/model/KailleraGame.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/model/KailleraGame.kt
@@ -4,10 +4,7 @@ import com.google.common.flogger.FluentLogger
 import com.google.protobuf.util.Timestamps
 import io.netty.buffer.ByteBuf
 import io.netty.buffer.PooledByteBufAllocator
-import java.io.FileOutputStream
 import java.util.Date
-import java.util.zip.GZIPOutputStream
-import kotlin.io.path.createTempDirectory
 import kotlin.time.Clock
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
@@ -135,6 +132,7 @@ class KailleraGame(
   var aConnection = "any"
   val startDate: Date = Date()
   private var gameStartTimeNs: Long = 0L
+  private var pendingSurveyGameLog: ByteArray? = null
 
   @JvmField var swap = false
 
@@ -683,22 +681,6 @@ class KailleraGame(
     }
     autoFireDetector.stop()
     players.clear()
-
-    // Write the game log out to a compressed file.
-    val gameLog = gameLogBuilder?.build()
-    if (gameLog != null) {
-      try {
-        val filePath = createTempDirectory("gamelog").resolve("gamelog.bin.gz").toFile()
-        FileOutputStream(filePath).use { fos ->
-          GZIPOutputStream(fos).use { gzipOut ->
-            gzipOut.write(gameLog.toByteArray())
-            logger.atInfo().log("Stored game log for game %d at %s", id, filePath)
-          }
-        }
-      } catch (e: Exception) {
-        logger.atWarning().withCause(e).log("Failed to save game log for game %d", id)
-      }
-    }
   }
 
   @Synchronized
@@ -763,14 +745,29 @@ class KailleraGame(
     playerActionQueues?.get(playerNumber - 1)?.addActions(data)
     autoFireDetector.addData(playerNumber, data, user.bytesPerAction)
 
-    if (flags.surveyEnabled && status == GameStatus.PLAYING && user.surveyConsent == true) {
+    if (flags.surveyEnabled && status == GameStatus.PLAYING) {
       val nowNs = System.nanoTime()
       if (nowNs - gameStartTimeNs > 8.minutes.inWholeNanoseconds) {
-        if (nowNs - user.lastSurveyAskedTimeNs > 10.minutes.inWholeNanoseconds) {
-          if (user.frameCount % 3 == 0) {
-            if (checkStartPressed(data, user.bytesPerAction)) {
-              askSurveyQuestion(user)
-              user.lastSurveyAskedTimeNs = nowNs
+        val eligiblePlayers =
+          players.filter {
+            it.surveyConsent == true &&
+              (nowNs - it.lastSurveyAskedTimeNs) > 10.minutes.inWholeNanoseconds
+          }
+        if (eligiblePlayers.isNotEmpty() && user.frameCount % 3 == 0) {
+          if (checkStartPressed(data, user.bytesPerAction)) {
+            // Snapshot the rolling 5-minute window
+            val fiveMinsAgoNs = nowNs - 5.minutes.inWholeNanoseconds
+            val recentEvents =
+              gameLogBuilder?.eventsList?.filter { it.timestampNs >= fiveMinsAgoNs }
+            val snapshotBuilder = GameLog.newBuilder()
+            if (recentEvents != null) {
+              snapshotBuilder.addAllEvents(recentEvents)
+            }
+            pendingSurveyGameLog = snapshotBuilder.build().toByteArray()
+
+            for (player in eligiblePlayers) {
+              askSurveyQuestion(player)
+              player.lastSurveyAskedTimeNs = nowNs
             }
           }
         }
@@ -786,21 +783,20 @@ class KailleraGame(
   }
 
   private fun askSurveyQuestion(player: KailleraUser) {
-    val question = EmuLang.getString("Survey.Question", "10")
-    announce("SURVEY: $question", player)
+    announce("SURVEY: ${EmuLang.getString("Survey.Question", "10")}", player)
   }
 
   private fun reportSurveyResponse(user: KailleraUser, response: String) {
-    val gameLog = gameLogBuilder?.build()?.toByteArray()
+    val surveyLog = pendingSurveyGameLog
     logger
       .atInfo()
       .log(
         "Reporting survey response for %s: %s (Proto data size: %d)",
         user.name,
         response,
-        gameLog?.size ?: 0,
+        surveyLog?.size ?: 0,
       )
-    // TODO: Send response and gameLog to a server for analysis.
+    // TODO: Send response and surveyLog to a server for analysis.
   }
 
   /**
@@ -927,6 +923,14 @@ class KailleraGame(
           }
         )
         lastLagstatNs = nowNs
+
+        // Prune the game log to a 5-minute rolling window to prevent unbounded memory growth.
+        val fiveMinsAgoNs = nowNs - 5.minutes.inWholeNanoseconds
+        val recentEvents = glb.eventsList.takeLastWhile { it.timestampNs >= fiveMinsAgoNs }
+        if (recentEvents.size < glb.eventsCount) {
+          glb.clearEvents()
+          glb.addAllEvents(recentEvents)
+        }
       }
     }
 

--- a/emulinker/src/main/java/org/emulinker/kaillera/model/KailleraUser.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/model/KailleraUser.kt
@@ -440,6 +440,7 @@ class KailleraUser(
             is AddDataResult.Failure -> return Result.failure(r.exception)
           }
         }
+        frameCount++
       }
       gameDataErrorTime = 0
       return Result.success(Unit)

--- a/emulinker/src/main/java/org/emulinker/kaillera/model/KailleraUser.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/model/KailleraUser.kt
@@ -133,6 +133,8 @@ class KailleraUser(
   var isAcceptingDirectMessages = true
   var lastMsgID = -1
   var isMuted = false
+  var surveyConsent: Boolean? = null
+  var lastSurveyAskedTimeNs: Long = 0L
 
   private val lostInput: MutableList<ByteBuf> = ArrayList()
 

--- a/emulinker/src/main/java/org/emulinker/kaillera/model/KailleraUser.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/model/KailleraUser.kt
@@ -7,6 +7,7 @@ import java.net.InetSocketAddress
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Instant
+import kotlin.time.TimeMark
 import org.emulinker.config.RuntimeFlags
 import org.emulinker.kaillera.access.AccessManager
 import org.emulinker.kaillera.controller.v086.V086ClientHandler
@@ -134,7 +135,8 @@ class KailleraUser(
   var lastMsgID = -1
   var isMuted = false
   var surveyConsent: Boolean? = null
-  var lastSurveyAskedTimeNs: Long = 0L
+  var surveyConsentAskedTimeMark: TimeMark? = null
+  var lastSurveyAskedTimeMark: TimeMark? = null
 
   private val lostInput: MutableList<ByteBuf> = ArrayList()
 

--- a/emulinker/src/main/java/org/emulinker/kaillera/model/KailleraUser.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/model/KailleraUser.kt
@@ -136,7 +136,6 @@ class KailleraUser(
   var isMuted = false
   var surveyConsent: Boolean? = null
   var surveyConsentAskedTimeMark: TimeMark? = null
-  var lastSurveyAskedTimeMark: TimeMark? = null
 
   private val lostInput: MutableList<ByteBuf> = ArrayList()
 

--- a/emulinker/src/main/java/org/emulinker/kaillera/model/SurveyManager.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/model/SurveyManager.kt
@@ -29,7 +29,8 @@ class SurveyManager(private val game: KailleraGame) : KoinComponent {
   private var gameStartTimeMark: TimeMark? = null
   var lastSurveyAskedTimeMark: TimeMark? = null
   private var pendingSurveyGameLog: ByteArray? = null
-  private var gameLogBuilder: GameLog.Builder? = null
+  private val telemetryEvents = ArrayDeque<Event>()
+  private var isRecordingTelemetry = false
 
   fun onGameStarted() {
     if (isSurveyEligibleForGame) {
@@ -63,7 +64,8 @@ class SurveyManager(private val game: KailleraGame) : KoinComponent {
 
     if (eligiblePlayers.isNotEmpty()) {
       if (checkStartPressed(data, bytesPerAction)) {
-        pendingSurveyGameLog = gameLogBuilder?.build()?.toByteArray()
+        pendingSurveyGameLog =
+          GameLog.newBuilder().addAllEvents(telemetryEvents).build().toByteArray()
         for (player in eligiblePlayers) {
           game.announce("SURVEY: ${EmuLang.getString("Survey.Question", "10")}", player)
         }
@@ -73,10 +75,14 @@ class SurveyManager(private val game: KailleraGame) : KoinComponent {
   }
 
   fun logReceivedGameData(playerNumber: Int, timestampNs: Long?) {
-    val glb = gameLogBuilder ?: return
-    glb.addEvents(
+    if (!isRecordingTelemetry) return
+    if (timestampNs == null) {
+      logger.atWarning().log("Skipping logReceivedGameData because timestampNs is null")
+      return
+    }
+    telemetryEvents.add(
       event {
-        this.timestampNs = checkNotNull(timestampNs) { "user's receivedGameDataNs is null!" }
+        this.timestampNs = timestampNs
         receivedGameData =
           when (playerNumber) {
             1 -> RECEIVED_FROM_P1
@@ -168,10 +174,9 @@ class SurveyManager(private val game: KailleraGame) : KoinComponent {
   fun updateDrift(nowNs: Long, lagstatData: Event.LagstatSummary?) {
     if (!isSurveyEligibleForGame) return
 
-    if (shouldRecordTelemetry() && gameLogBuilder == null) {
-      gameLogBuilder = GameLog.newBuilder()
-    } else if (!shouldRecordTelemetry()) {
-      gameLogBuilder = null
+    isRecordingTelemetry = shouldRecordTelemetry()
+    if (!isRecordingTelemetry) {
+      telemetryEvents.clear()
     }
 
     if (pendingSurveyGameLog != null) {
@@ -185,9 +190,8 @@ class SurveyManager(private val game: KailleraGame) : KoinComponent {
       }
     }
 
-    val glb = gameLogBuilder
-    if (glb != null) {
-      glb.addEvents(
+    if (isRecordingTelemetry) {
+      telemetryEvents.add(
         event {
           timestampNs = nowNs
           fanOut = FAN_OUT
@@ -195,7 +199,7 @@ class SurveyManager(private val game: KailleraGame) : KoinComponent {
       )
 
       if (lagstatData != null) {
-        glb.addEvents(
+        telemetryEvents.add(
           event {
             timestampNs = nowNs
             lagstatSummary = lagstatData
@@ -205,10 +209,8 @@ class SurveyManager(private val game: KailleraGame) : KoinComponent {
 
       // Prune the game log to a 5-minute rolling window to prevent unbounded memory growth.
       val fiveMinsAgoNs = nowNs - SURVEY_TELEMETRY_WINDOW.inWholeNanoseconds
-      val recentEvents = glb.eventsList.takeLastWhile { it.timestampNs >= fiveMinsAgoNs }
-      if (recentEvents.size < glb.eventsCount) {
-        glb.clearEvents()
-        glb.addAllEvents(recentEvents)
+      while (telemetryEvents.isNotEmpty() && telemetryEvents.first().timestampNs < fiveMinsAgoNs) {
+        telemetryEvents.removeFirst()
       }
     }
   }

--- a/emulinker/src/main/java/org/emulinker/kaillera/model/SurveyManager.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/model/SurveyManager.kt
@@ -67,7 +67,10 @@ class SurveyManager(private val game: KailleraGame) : KoinComponent {
         pendingSurveyGameLog =
           GameLog.newBuilder().addAllEvents(telemetryEvents).build().toByteArray()
         for (player in eligiblePlayers) {
-          game.announce("SURVEY: ${EmuLang.getString("Survey.Question", "10")}", player)
+          game.announce(
+            "SURVEY: ${EmuLang.getString("Survey.Question", SURVEY_TELEMETRY_WINDOW.inWholeMinutes.toString())}",
+            player,
+          )
         }
         lastSurveyAskedTimeMark = TimeSource.Monotonic.markNow()
       }

--- a/emulinker/src/main/java/org/emulinker/kaillera/model/SurveyManager.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/model/SurveyManager.kt
@@ -1,0 +1,231 @@
+package org.emulinker.kaillera.model
+
+import com.google.common.flogger.FluentLogger
+import io.netty.buffer.ByteBuf
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.TimeMark
+import kotlin.time.TimeSource
+import org.emulinker.config.RuntimeFlags
+import org.emulinker.proto.Event
+import org.emulinker.proto.EventKt.fanOut
+import org.emulinker.proto.EventKt.receivedGameData
+import org.emulinker.proto.GameLog
+import org.emulinker.proto.Player.PLAYER_FOUR
+import org.emulinker.proto.Player.PLAYER_ONE
+import org.emulinker.proto.Player.PLAYER_THREE
+import org.emulinker.proto.Player.PLAYER_TWO
+import org.emulinker.proto.event
+import org.emulinker.util.EmuLang
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+class SurveyManager(private val game: KailleraGame) : KoinComponent {
+
+  private val flags: RuntimeFlags by inject()
+
+  val isSurveyEligibleForGame =
+    flags.surveyEnabled && flags.surveyGameWhitelist.any { Regex(it).containsMatchIn(game.romName) }
+
+  private var gameStartTimeMark: TimeMark? = null
+  var lastSurveyAskedTimeMark: TimeMark? = null
+  private var pendingSurveyGameLog: ByteArray? = null
+  private var gameLogBuilder: GameLog.Builder? = null
+
+  fun onGameStarted() {
+    if (isSurveyEligibleForGame) {
+      gameStartTimeMark = TimeSource.Monotonic.markNow()
+    }
+  }
+
+  /** If eligible, ask the user for survey consent when they join the game. */
+  fun onUserJoined(user: KailleraUser) {
+    if (isSurveyEligibleForGame && user.surveyConsent == null) {
+      game.announce(EmuLang.getString("Survey.Consent"), user)
+      user.surveyConsentAskedTimeMark = TimeSource.Monotonic.markNow()
+    }
+  }
+
+  /**
+   * If a survey is active, check for a user pressing "start" once every three frames to trigger a
+   * survey for all users.
+   */
+  fun onControllerInput(user: KailleraUser, data: ByteBuf, bytesPerAction: Int) {
+    if (!isSurveyEligibleForGame || game.status != GameStatus.PLAYING) return
+    if (user.frameCount % 3 != 0) return
+
+    val gameStart = gameStartTimeMark ?: return
+    if (gameStart.elapsedNow() <= SURVEY_GAME_START_DELAY) return
+
+    val lastAsked = lastSurveyAskedTimeMark
+    if (lastAsked != null && lastAsked.elapsedNow() <= SURVEY_COOLDOWN) return
+
+    val eligiblePlayers = game.players.filter { it.surveyConsent == true }
+
+    if (eligiblePlayers.isNotEmpty()) {
+      if (checkStartPressed(data, bytesPerAction)) {
+        pendingSurveyGameLog = gameLogBuilder?.build()?.toByteArray()
+        for (player in eligiblePlayers) {
+          game.announce("SURVEY: ${EmuLang.getString("Survey.Question", "10")}", player)
+        }
+        lastSurveyAskedTimeMark = TimeSource.Monotonic.markNow()
+      }
+    }
+  }
+
+  fun logReceivedGameData(playerNumber: Int, timestampNs: Long?) {
+    val glb = gameLogBuilder ?: return
+    glb.addEvents(
+      event {
+        this.timestampNs = checkNotNull(timestampNs) { "user's receivedGameDataNs is null!" }
+        receivedGameData =
+          when (playerNumber) {
+            1 -> RECEIVED_FROM_P1
+            2 -> RECEIVED_FROM_P2
+            3 -> RECEIVED_FROM_P3
+            4 -> RECEIVED_FROM_P4
+            else -> throw IllegalStateException("Player number is out of bounds!")
+          }
+      }
+    )
+  }
+
+  private fun checkStartPressed(data: ByteBuf, bytesPerAction: Int): Boolean {
+    if (data.readableBytes() < 13) return false
+    return (data.getByte(data.readerIndex() + 12).toInt() and 0b00010000) != 0
+  }
+
+  fun handleChat(user: KailleraUser, message: String): Boolean {
+    if (!isSurveyEligibleForGame) return false
+
+    // Check for consent response
+    if (user.surveyConsent == null) {
+      val askedTime = user.surveyConsentAskedTimeMark
+      if (askedTime != null && askedTime.elapsedNow() <= SURVEY_CONSENT_TIMEOUT) {
+        when (message.lowercase()) {
+          "y",
+          "yes" -> {
+            user.surveyConsent = true
+            game.announce(EmuLang.getString("Survey.ConsentYes"), user)
+            return true
+          }
+          "n",
+          "no" -> {
+            user.surveyConsent = false
+            game.announce(EmuLang.getString("Survey.ConsentNo"), user)
+            return true
+          }
+        }
+      }
+    }
+
+    // Check for survey response
+    if (message.trim().matches("[1-3]".toRegex())) {
+      val lastAsked = lastSurveyAskedTimeMark
+      if (lastAsked != null && lastAsked.elapsedNow() <= MAX_SURVEY_RESPONSE_TIME) {
+        reportSurveyResponse(user, message.trim())
+        game.announce(EmuLang.getString("Survey.Thanks"), user)
+        return true
+      }
+    }
+
+    return false
+  }
+
+  private fun reportSurveyResponse(user: KailleraUser, response: String) {
+    val surveyLog = pendingSurveyGameLog
+    logger
+      .atInfo()
+      .log(
+        "Reporting survey response for %s: %s (Proto data size: %d)",
+        user.name,
+        response,
+        surveyLog?.size ?: 0,
+      )
+    // TODO: Send response and surveyLog to a server for analysis.
+  }
+
+  /**
+   * Determines if the game log builder should active capture telemetry. To save memory, telemetry
+   * is ONLY buffered during the SURVEY_TELEMETRY_WINDOW (5 mins) immediately preceding a potential
+   * survey prompt limit.
+   */
+  private fun shouldRecordTelemetry(): Boolean {
+    if (!isSurveyEligibleForGame || game.status != GameStatus.PLAYING) return false
+    val gameStart = gameStartTimeMark ?: return false
+
+    val needsToRecordForFirstSurvey =
+      gameStart.elapsedNow() >= (SURVEY_GAME_START_DELAY - SURVEY_TELEMETRY_WINDOW)
+
+    val timeLimitSatisfied =
+      when (val lastAsked = lastSurveyAskedTimeMark) {
+        null -> needsToRecordForFirstSurvey
+        else -> lastAsked.elapsedNow() >= (SURVEY_COOLDOWN - SURVEY_TELEMETRY_WINDOW)
+      }
+
+    return timeLimitSatisfied && game.players.any { it.surveyConsent == true }
+  }
+
+  fun updateDrift(nowNs: Long, lagstatData: Event.LagstatSummary?) {
+    if (!isSurveyEligibleForGame) return
+
+    if (shouldRecordTelemetry() && gameLogBuilder == null) {
+      gameLogBuilder = GameLog.newBuilder()
+    } else if (!shouldRecordTelemetry()) {
+      gameLogBuilder = null
+    }
+
+    if (pendingSurveyGameLog != null) {
+      val lastAsked = lastSurveyAskedTimeMark
+      val anyoneStillResponding =
+        lastAsked != null &&
+          lastAsked.elapsedNow() <= MAX_SURVEY_RESPONSE_TIME &&
+          game.players.any { it.surveyConsent == true }
+      if (!anyoneStillResponding) {
+        pendingSurveyGameLog = null
+      }
+    }
+
+    val glb = gameLogBuilder
+    if (glb != null) {
+      glb.addEvents(
+        event {
+          timestampNs = nowNs
+          fanOut = FAN_OUT
+        }
+      )
+
+      if (lagstatData != null) {
+        glb.addEvents(
+          event {
+            timestampNs = nowNs
+            lagstatSummary = lagstatData
+          }
+        )
+      }
+
+      // Prune the game log to a 5-minute rolling window to prevent unbounded memory growth.
+      val fiveMinsAgoNs = nowNs - SURVEY_TELEMETRY_WINDOW.inWholeNanoseconds
+      val recentEvents = glb.eventsList.takeLastWhile { it.timestampNs >= fiveMinsAgoNs }
+      if (recentEvents.size < glb.eventsCount) {
+        glb.clearEvents()
+        glb.addAllEvents(recentEvents)
+      }
+    }
+  }
+
+  companion object {
+    private val logger = FluentLogger.forEnclosingClass()
+
+    val SURVEY_CONSENT_TIMEOUT = 4.minutes
+    val MAX_SURVEY_RESPONSE_TIME = 1.5.minutes
+    val SURVEY_GAME_START_DELAY = 8.minutes
+    val SURVEY_COOLDOWN = 10.minutes
+    val SURVEY_TELEMETRY_WINDOW = 5.minutes
+
+    private val FAN_OUT = fanOut {}
+    private val RECEIVED_FROM_P1 = receivedGameData { receivedFrom = PLAYER_ONE }
+    private val RECEIVED_FROM_P2 = receivedGameData { receivedFrom = PLAYER_TWO }
+    private val RECEIVED_FROM_P3 = receivedGameData { receivedFrom = PLAYER_THREE }
+    private val RECEIVED_FROM_P4 = receivedGameData { receivedFrom = PLAYER_FOUR }
+  }
+}

--- a/emulinker/src/main/java/org/emulinker/kaillera/pico/KoinModule.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/pico/KoinModule.kt
@@ -179,6 +179,7 @@ val koinModule = module {
             config.getStringArray("twitter.preventBroadcastNameSuffixes").toList(),
           v086BufferSize = config.getInt("controllers.v086.bufferSize", 4096),
           surveyEnabled = config.getBoolean("survey.enabled", false),
+          surveyGameWhitelist = config.getStringArray("survey.gameWhitelist").toList(),
         )
 
       charsetDoNotUse = flags.charset

--- a/emulinker/src/main/java/org/emulinker/kaillera/pico/KoinModule.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/pico/KoinModule.kt
@@ -178,6 +178,7 @@ val koinModule = module {
           twitterPreventBroadcastNameSuffixes =
             config.getStringArray("twitter.preventBroadcastNameSuffixes").toList(),
           v086BufferSize = config.getInt("controllers.v086.bufferSize", 4096),
+          surveyEnabled = config.getBoolean("survey.enabled", false),
         )
 
       charsetDoNotUse = flags.charset

--- a/emulinker/src/test/java/org/emulinker/kaillera/access/AccessManager2Test.kt
+++ b/emulinker/src/test/java/org/emulinker/kaillera/access/AccessManager2Test.kt
@@ -351,6 +351,7 @@ class AccessManager2Test {
         twitterPreventBroadcastNameSuffixes = emptyList(),
         v086BufferSize = 4096,
         surveyEnabled = false,
+        surveyGameWhitelist = emptyList(),
       )
   }
 }

--- a/emulinker/src/test/java/org/emulinker/kaillera/access/AccessManager2Test.kt
+++ b/emulinker/src/test/java/org/emulinker/kaillera/access/AccessManager2Test.kt
@@ -350,6 +350,7 @@ class AccessManager2Test {
         twitterOAuthConsumerSecret = "",
         twitterPreventBroadcastNameSuffixes = emptyList(),
         v086BufferSize = 4096,
+        surveyEnabled = false,
       )
   }
 }

--- a/emulinker/src/test/java/org/emulinker/kaillera/controller/GameDataE2ETest.kt
+++ b/emulinker/src/test/java/org/emulinker/kaillera/controller/GameDataE2ETest.kt
@@ -40,6 +40,7 @@ import org.emulinker.kaillera.controller.v086.protocol.UserJoined
 import org.emulinker.kaillera.controller.v086.protocol.V086Bundle
 import org.emulinker.kaillera.controller.v086.protocol.V086Message
 import org.emulinker.kaillera.model.ConnectionType
+import org.emulinker.kaillera.model.KailleraServer
 import org.emulinker.kaillera.pico.AppModule
 import org.emulinker.kaillera.pico.koinModule
 import org.emulinker.util.FastGameDataCache
@@ -196,6 +197,11 @@ class GameDataE2ETest : KoinComponent {
         expect.that(receivedBytes).isEqualTo(expectedData)
       }
     }
+
+    val server = get<KailleraServer>()
+    val serverUser = checkNotNull(server.usersMap.values.find { it.name == "User1" })
+    expect.that(serverUser.frameCount).isEqualTo(1000)
+
     println("Shutting down...")
     client.quitGame()
     client.quit()

--- a/emulinker/src/test/java/org/emulinker/kaillera/model/KailleraUserTest.kt
+++ b/emulinker/src/test/java/org/emulinker/kaillera/model/KailleraUserTest.kt
@@ -89,6 +89,8 @@ class KailleraUserTest {
       twitterOAuthConsumerSecret = "",
       twitterPreventBroadcastNameSuffixes = emptyList(),
       v086BufferSize = 4096,
+      surveyEnabled = false,
+      surveyGameWhitelist = emptyList(),
     )
 
   private val mockClientHandler = mock<V086ClientHandler>()

--- a/emulinker/src/test/java/org/emulinker/kaillera/model/SurveyManagerTest.kt
+++ b/emulinker/src/test/java/org/emulinker/kaillera/model/SurveyManagerTest.kt
@@ -5,6 +5,7 @@ import io.netty.buffer.Unpooled
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.time.Duration.Companion.minutes
 import kotlin.time.TimeMark
 import kotlin.time.TimeSource
 import org.emulinker.config.RuntimeFlags
@@ -224,6 +225,75 @@ class SurveyManagerTest {
     // Should not throw and should not announce anything.
     manager.onControllerInput(consentedUser, data, 2)
     verify(waitingGame, never()).announce(any(), any())
+    data.release()
+  }
+
+  @Test
+  fun `onControllerInput checks start button and triggers survey when frameCount is a multiple of 3`() {
+    val user: KailleraUser = mock {
+      on { frameCount } doReturn 6 // 6 is multiple of 3
+      on { surveyConsent } doReturn true
+    }
+    val playingGame =
+      mock<KailleraGame> {
+        on { romName } doReturn "smash"
+        on { status } doReturn GameStatus.PLAYING
+        on { players } doReturn mutableListOf(user)
+      }
+
+    val manager = SurveyManager(playingGame)
+
+    // Use reflection to set gameStartTimeMark to 9 minutes ago
+    val field = SurveyManager::class.java.getDeclaredField("gameStartTimeMark")
+    field.isAccessible = true
+    field.set(manager, TimeSource.Monotonic.markNow() - 9.minutes)
+
+    // N64 controller data layout with start bit set at byte 12 (0x10)
+    val data =
+      Unpooled.buffer(24).apply {
+        writeZero(12)
+        writeByte(0x10) // start button pressed
+        writeZero(11)
+      }
+
+    manager.onControllerInput(user, data, 2)
+
+    verify(playingGame).announce(any(), org.mockito.kotlin.eq(user))
+    data.release()
+  }
+
+  @Test
+  fun `onControllerInput does not check start button when frameCount is not a multiple of 3`() {
+    val user: KailleraUser = mock {
+      on { frameCount } doReturn 7 // 7 is not a multiple of 3
+      on { surveyConsent } doReturn true
+    }
+    val playingGame =
+      mock<KailleraGame> {
+        on { romName } doReturn "smash"
+        on { status } doReturn GameStatus.PLAYING
+        on { players } doReturn mutableListOf(user)
+      }
+
+    val manager = SurveyManager(playingGame)
+
+    // Use reflection to set gameStartTimeMark to 9 minutes ago
+    val field = SurveyManager::class.java.getDeclaredField("gameStartTimeMark")
+    field.isAccessible = true
+    field.set(manager, TimeSource.Monotonic.markNow() - 9.minutes)
+
+    // N64 controller data layout with start bit set at byte 12 (0x10)
+    val data =
+      Unpooled.buffer(24).apply {
+        writeZero(12)
+        writeByte(0x10) // start button pressed
+        writeZero(11)
+      }
+
+    manager.onControllerInput(user, data, 2)
+
+    // Should return early and NOT trigger survey (never announce)
+    verify(playingGame, never()).announce(any(), any())
     data.release()
   }
 }

--- a/emulinker/src/test/java/org/emulinker/kaillera/model/SurveyManagerTest.kt
+++ b/emulinker/src/test/java/org/emulinker/kaillera/model/SurveyManagerTest.kt
@@ -9,6 +9,7 @@ import kotlin.time.Duration.Companion.minutes
 import kotlin.time.TimeMark
 import kotlin.time.TimeSource
 import org.emulinker.config.RuntimeFlags
+import org.emulinker.proto.GameLog
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
 import org.koin.dsl.module
@@ -294,6 +295,157 @@ class SurveyManagerTest {
 
     // Should return early and NOT trigger survey (never announce)
     verify(playingGame, never()).announce(any(), any())
+    data.release()
+  }
+
+  // ── Telemetry & Pruning ──────────────────────────────────────────────────────
+
+  @Test
+  fun `telemetry is not recorded before 3 minutes from game start`() {
+    val user = consentedUser
+    val playingGame =
+      mock<KailleraGame> {
+        on { romName } doReturn "smash"
+        on { status } doReturn GameStatus.PLAYING
+        on { players } doReturn mutableListOf(user)
+      }
+    val manager = SurveyManager(playingGame)
+    manager.onGameStarted()
+
+    // Game started 2 minutes ago
+    val field = SurveyManager::class.java.getDeclaredField("gameStartTimeMark")
+    field.isAccessible = true
+    field.set(manager, TimeSource.Monotonic.markNow() - 2.minutes)
+
+    // Call updateDrift to run state machine.
+    manager.updateDrift(System.nanoTime(), null)
+
+    // Call logReceivedGameData. It should be ignored because telemetry is not recording.
+    manager.logReceivedGameData(1, System.nanoTime())
+
+    // Set gameStartTimeMark to 9 minutes ago so onControllerInput passes the delay check
+    field.set(manager, TimeSource.Monotonic.markNow() - 9.minutes)
+
+    val data =
+      Unpooled.buffer(24).apply {
+        writeZero(12)
+        writeByte(0x10) // start button pressed
+        writeZero(11)
+      }
+
+    manager.onControllerInput(user, data, 2)
+
+    // Retrieve pendingSurveyGameLog
+    val pendingLogField = SurveyManager::class.java.getDeclaredField("pendingSurveyGameLog")
+    pendingLogField.isAccessible = true
+    val bytes = pendingLogField.get(manager) as ByteArray?
+
+    assertThat(bytes).isNotNull()
+    val gameLog = GameLog.parseFrom(bytes!!)
+    assertThat(gameLog.eventsCount).isEqualTo(0)
+    data.release()
+  }
+
+  @Test
+  fun `telemetry is recorded between 3 and 8 minutes from game start`() {
+    val user = consentedUser
+    val playingGame =
+      mock<KailleraGame> {
+        on { romName } doReturn "smash"
+        on { status } doReturn GameStatus.PLAYING
+        on { players } doReturn mutableListOf(user)
+      }
+    val manager = SurveyManager(playingGame)
+    manager.onGameStarted()
+
+    // Game started 4 minutes ago (satisfies needsToRecordForFirstSurvey: 4 >= 3)
+    val field = SurveyManager::class.java.getDeclaredField("gameStartTimeMark")
+    field.isAccessible = true
+    field.set(manager, TimeSource.Monotonic.markNow() - 4.minutes)
+
+    manager.updateDrift(System.nanoTime(), null) // Appends 1 fanOut event
+
+    // Call logReceivedGameData. It should be recorded.
+    manager.logReceivedGameData(1, System.nanoTime()) // Appends 1 receivedGameData event
+
+    // Set gameStartTimeMark to 9 minutes ago so onControllerInput passes the delay check
+    field.set(manager, TimeSource.Monotonic.markNow() - 9.minutes)
+
+    val data =
+      Unpooled.buffer(24).apply {
+        writeZero(12)
+        writeByte(0x10) // start button pressed
+        writeZero(11)
+      }
+
+    manager.onControllerInput(user, data, 2)
+
+    val pendingLogField = SurveyManager::class.java.getDeclaredField("pendingSurveyGameLog")
+    pendingLogField.isAccessible = true
+    val bytes = pendingLogField.get(manager) as ByteArray?
+
+    assertThat(bytes).isNotNull()
+    val gameLog = GameLog.parseFrom(bytes!!)
+
+    // Should contain 2 events: 1 fanOut and 1 receivedGameData
+    assertThat(gameLog.eventsCount).isEqualTo(2)
+    data.release()
+  }
+
+  @Test
+  fun `telemetry older than 5 minutes is pruned`() {
+    val user = consentedUser
+    val playingGame =
+      mock<KailleraGame> {
+        on { romName } doReturn "smash"
+        on { status } doReturn GameStatus.PLAYING
+        on { players } doReturn mutableListOf(user)
+      }
+    val manager = SurveyManager(playingGame)
+    manager.onGameStarted()
+
+    // Game started 4 minutes ago
+    val field = SurveyManager::class.java.getDeclaredField("gameStartTimeMark")
+    field.isAccessible = true
+    field.set(manager, TimeSource.Monotonic.markNow() - 4.minutes)
+
+    // Event 1 (timestampNs = 0L)
+    manager.updateDrift(0L, null)
+    manager.logReceivedGameData(1, 0L)
+
+    // Event 2 (timestampNs = 2 mins)
+    manager.updateDrift(2.minutes.inWholeNanoseconds, null)
+    manager.logReceivedGameData(1, 2.minutes.inWholeNanoseconds)
+
+    // Event 3 (timestampNs = 6 mins) -> Event 1 is now older than 5 mins (6 - 5 = 1 min), so it
+    // should be pruned.
+    // Event 2 is 4 mins old, so it should be kept.
+    manager.updateDrift(6.minutes.inWholeNanoseconds, null)
+
+    // Set gameStartTimeMark to 10 minutes ago so onControllerInput passes the delay check
+    field.set(manager, TimeSource.Monotonic.markNow() - 10.minutes)
+
+    val data =
+      Unpooled.buffer(24).apply {
+        writeZero(12)
+        writeByte(0x10) // start button pressed
+        writeZero(11)
+      }
+
+    manager.onControllerInput(user, data, 2)
+
+    val pendingLogField = SurveyManager::class.java.getDeclaredField("pendingSurveyGameLog")
+    pendingLogField.isAccessible = true
+    val bytes = pendingLogField.get(manager) as ByteArray?
+
+    assertThat(bytes).isNotNull()
+    val gameLog = GameLog.parseFrom(bytes!!)
+
+    // Check that none of the events in gameLog have timestampNs < 1 minute (6 mins - 5 mins)
+    val oneMinAgoNs = 1.minutes.inWholeNanoseconds
+    for (event in gameLog.eventsList) {
+      assertThat(event.timestampNs).isAtLeast(oneMinAgoNs)
+    }
     data.release()
   }
 }

--- a/emulinker/src/test/java/org/emulinker/kaillera/model/SurveyManagerTest.kt
+++ b/emulinker/src/test/java/org/emulinker/kaillera/model/SurveyManagerTest.kt
@@ -1,0 +1,229 @@
+package org.emulinker.kaillera.model
+
+import com.google.common.truth.Truth.assertThat
+import io.netty.buffer.Unpooled
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.time.TimeMark
+import kotlin.time.TimeSource
+import org.emulinker.config.RuntimeFlags
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+
+class SurveyManagerTest {
+
+  private val mockFlags =
+    mock<RuntimeFlags> {
+      on { surveyEnabled } doReturn true
+      on { surveyGameWhitelist } doReturn listOf("smash", "tekken")
+    }
+
+  // A user who has not yet given consent (surveyConsent == null, no timemark set).
+  private val pendingConsentUser: KailleraUser = mock {
+    on { frameCount } doReturn 3
+    on { surveyConsent } doReturn null
+    on { surveyConsentAskedTimeMark } doReturn null
+  }
+
+  // A user who has positively consented to surveys.
+  private val consentedUser: KailleraUser = mock {
+    on { frameCount } doReturn 3
+    on { surveyConsent } doReturn true
+    on { surveyConsentAskedTimeMark } doReturn TimeSource.Monotonic.markNow()
+  }
+
+  private val mockGame =
+    mock<KailleraGame> {
+      on { romName } doReturn "smash bros"
+      on { status } doReturn GameStatus.PLAYING
+      on { players } doReturn mutableListOf(pendingConsentUser)
+    }
+
+  @BeforeTest
+  fun setUp() {
+    startKoin { modules(module { single { mockFlags } }) }
+  }
+
+  @AfterTest
+  fun tearDown() {
+    stopKoin()
+  }
+
+  // ── Eligibility ──────────────────────────────────────────────────────────────
+
+  @Test
+  fun `isSurveyEligibleForGame is true when romName matches whitelist`() {
+    val manager = SurveyManager(mockGame)
+    assertThat(manager.isSurveyEligibleForGame).isTrue()
+  }
+
+  @Test
+  fun `isSurveyEligibleForGame is false when romName does not match whitelist`() {
+    val ineligibleGame = mock<KailleraGame> { on { romName } doReturn "mario kart" }
+    val manager = SurveyManager(ineligibleGame)
+    assertThat(manager.isSurveyEligibleForGame).isFalse()
+  }
+
+  @Test
+  fun `isSurveyEligibleForGame is false when surveyEnabled is false`() {
+    val disabledFlags =
+      mock<RuntimeFlags> {
+        on { surveyEnabled } doReturn false
+        on { surveyGameWhitelist } doReturn listOf("smash")
+      }
+    stopKoin()
+    startKoin { modules(module { single { disabledFlags } }) }
+
+    val manager = SurveyManager(mockGame)
+    assertThat(manager.isSurveyEligibleForGame).isFalse()
+  }
+
+  // ── onUserJoined ─────────────────────────────────────────────────────────────
+
+  @Test
+  fun `onUserJoined announces consent prompt and sets timemark for unconsenteed user`() {
+    val manager = SurveyManager(mockGame)
+    manager.onUserJoined(pendingConsentUser)
+
+    verify(mockGame).announce(any(), org.mockito.kotlin.eq(pendingConsentUser))
+    verify(pendingConsentUser).surveyConsentAskedTimeMark = any()
+  }
+
+  @Test
+  fun `onUserJoined does nothing when game is not eligible`() {
+    val ineligibleGame = mock<KailleraGame> { on { romName } doReturn "mario kart" }
+    val manager = SurveyManager(ineligibleGame)
+    manager.onUserJoined(pendingConsentUser)
+
+    verify(ineligibleGame, never()).announce(any(), any())
+  }
+
+  @Test
+  fun `onUserJoined does not re-prompt a user who already consented`() {
+    val manager = SurveyManager(mockGame)
+    manager.onUserJoined(consentedUser)
+
+    verify(mockGame, never()).announce(any(), org.mockito.kotlin.eq(consentedUser))
+  }
+
+  // ── handleChat — consent ──────────────────────────────────────────────────────
+
+  @Test
+  fun `handleChat returns false for ineligible game`() {
+    val ineligibleGame = mock<KailleraGame> { on { romName } doReturn "mario kart" }
+    val manager = SurveyManager(ineligibleGame)
+
+    assertThat(manager.handleChat(pendingConsentUser, "yes")).isFalse()
+  }
+
+  @Test
+  fun `handleChat accepts yes consent when timemark is set and within timeout`() {
+    // Give the user a timemark that is fresh (i.e. just now).
+    val freshMark: TimeMark = TimeSource.Monotonic.markNow()
+    val user: KailleraUser = mock {
+      on { surveyConsent } doReturn null
+      on { surveyConsentAskedTimeMark } doReturn freshMark
+    }
+    val manager = SurveyManager(mockGame)
+
+    val handled = manager.handleChat(user, "yes")
+    assertThat(handled).isTrue()
+    verify(user).surveyConsent = true
+  }
+
+  @Test
+  fun `handleChat accepts y shorthand for yes consent`() {
+    val freshMark: TimeMark = TimeSource.Monotonic.markNow()
+    val user: KailleraUser = mock {
+      on { surveyConsent } doReturn null
+      on { surveyConsentAskedTimeMark } doReturn freshMark
+    }
+    val manager = SurveyManager(mockGame)
+
+    val handled = manager.handleChat(user, "y")
+    assertThat(handled).isTrue()
+    verify(user).surveyConsent = true
+  }
+
+  @Test
+  fun `handleChat accepts no consent when timemark is fresh`() {
+    val freshMark: TimeMark = TimeSource.Monotonic.markNow()
+    val user: KailleraUser = mock {
+      on { surveyConsent } doReturn null
+      on { surveyConsentAskedTimeMark } doReturn freshMark
+    }
+    val manager = SurveyManager(mockGame)
+
+    val handled = manager.handleChat(user, "no")
+    assertThat(handled).isTrue()
+    verify(user).surveyConsent = false
+  }
+
+  @Test
+  fun `handleChat does not accept consent when timemark is null`() {
+    // surveyConsentAskedTimeMark is null => consent window hasn't opened
+    val user: KailleraUser = mock {
+      on { surveyConsent } doReturn null
+      on { surveyConsentAskedTimeMark } doReturn null
+    }
+    val manager = SurveyManager(mockGame)
+
+    val handled = manager.handleChat(user, "yes")
+    assertThat(handled).isFalse()
+    verify(user, never()).surveyConsent = any()
+  }
+
+  // ── handleChat — survey response ──────────────────────────────────────────────
+
+  @Test
+  fun `handleChat accepts a numeric rating when survey was recently asked`() {
+    val manager = SurveyManager(mockGame)
+    // Simulate a survey having just been triggered.
+    manager.lastSurveyAskedTimeMark = TimeSource.Monotonic.markNow()
+
+    val handled = manager.handleChat(consentedUser, "2")
+    assertThat(handled).isTrue()
+  }
+
+  @Test
+  fun `handleChat ignores a numeric rating when lastSurveyAskedTimeMark is null`() {
+    val manager = SurveyManager(mockGame) // lastSurveyAskedTimeMark stays null
+
+    val handled = manager.handleChat(consentedUser, "2")
+    assertThat(handled).isFalse()
+  }
+
+  @Test
+  fun `handleChat returns false for unrelated chat messages`() {
+    val manager = SurveyManager(mockGame)
+
+    assertThat(manager.handleChat(consentedUser, "gg wp")).isFalse()
+  }
+
+  // ── onControllerInput ─────────────────────────────────────────────────────────
+
+  @Test
+  fun `onControllerInput bails early when game status is WAITING`() {
+    val waitingGame =
+      mock<KailleraGame> {
+        on { romName } doReturn "smash"
+        on { status } doReturn GameStatus.WAITING
+        on { players } doReturn mutableListOf(consentedUser)
+      }
+    val manager = SurveyManager(waitingGame)
+    manager.onGameStarted() // sets gameStartTimeMark
+
+    val data = Unpooled.buffer(16).apply { writeZero(16) }
+    // Should not throw and should not announce anything.
+    manager.onControllerInput(consentedUser, data, 2)
+    verify(waitingGame, never()).announce(any(), any())
+    data.release()
+  }
+}

--- a/release/start-server.sh
+++ b/release/start-server.sh
@@ -13,10 +13,36 @@ SEARCH_TERM="EmuLinker-K version"
 JAVA_OPTS="-Xms64m -Xmx256m -XX:+UseSerialGC -XX:+AlwaysPreTouch"
 CLASSPATH="./conf:$JAR_FILE"
 
-# Check for foreground flag
+# Check for foreground and jar flags
 FOREGROUND_MODE=false
-if [[ "$1" == "--foreground" ]]; then
-    FOREGROUND_MODE=true
+JAR_OVERRIDE=""
+
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --foreground)
+            FOREGROUND_MODE=true
+            ;;
+        --jar|-j)
+            if [[ -n "$2" && "$2" != -* ]]; then
+                JAR_OVERRIDE="$2"
+                shift
+            else
+                echo "❌ Error: --jar requires a file path argument."
+                exit 1
+            fi
+            ;;
+        *)
+            echo "❌ Error: Unknown parameter: $1"
+            echo "   Usage: $0 [--foreground] [--jar <path>]"
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+if [ -n "$JAR_OVERRIDE" ]; then
+    JAR_FILE="$JAR_OVERRIDE"
+    CLASSPATH="./conf:$JAR_FILE"
 fi
 
 # 3. PRE-FLIGHT CHECKS
@@ -42,37 +68,41 @@ if pgrep -f "$MAIN_CLASS" > /dev/null; then
 fi
 
 # 3.b UPDATE CHECK
-echo "🔍 Checking for updates..."
-PROD_TXT=$(curl -fsSL --max-time 3 "https://raw.githubusercontent.com/hopskipnfall/EmuLinker-K/prod/release/prod.txt" || true)
+if [ -z "$JAR_OVERRIDE" ]; then
+    echo "🔍 Checking for updates..."
+    PROD_TXT=$(curl -fsSL --max-time 3 "https://raw.githubusercontent.com/hopskipnfall/EmuLinker-K/prod/release/prod.txt" || true)
 
-if [ -n "$PROD_TXT" ]; then
-    LATEST_VERSION=$(echo "$PROD_TXT" | grep "^version=" | cut -d'=' -f2)
-    RELEASE_NOTES=$(echo "$PROD_TXT" | grep "^releaseNotes=" | cut -d'=' -f2)
+    if [ -n "$PROD_TXT" ]; then
+        LATEST_VERSION=$(echo "$PROD_TXT" | grep "^version=" | cut -d'=' -f2)
+        RELEASE_NOTES=$(echo "$PROD_TXT" | grep "^releaseNotes=" | cut -d'=' -f2)
 
-    # Extract local version from JAR filename
-    # Assumes JAR_FILE format: .../emulinker-k-VERSION.jar
-    LOCAL_VERSION=$(basename "$JAR_FILE" | sed -E 's/emulinker-k-(.+)\.jar/\1/')
+        # Extract local version from JAR filename
+        # Assumes JAR_FILE format: .../emulinker-k-VERSION.jar
+        LOCAL_VERSION=$(basename "$JAR_FILE" | sed -E 's/emulinker-k-(.+)\.jar/\1/')
 
-    if [ -n "$LATEST_VERSION" ] && [ -n "$LOCAL_VERSION" ]; then
-        if [ "$LATEST_VERSION" != "$LOCAL_VERSION" ]; then
-            echo -e "\n⚠️  \033[1;33mUpdate Available!\033[0m"
-            echo "   Current: $LOCAL_VERSION"
-            echo "   Latest:  $LATEST_VERSION"
-            if [ -n "$RELEASE_NOTES" ]; then
-                echo "   Release Notes: $RELEASE_NOTES"
+        if [ -n "$LATEST_VERSION" ] && [ -n "$LOCAL_VERSION" ]; then
+            if [ "$LATEST_VERSION" != "$LOCAL_VERSION" ]; then
+                echo -e "\n⚠️  \033[1;33mUpdate Available!\033[0m"
+                echo "   Current: $LOCAL_VERSION"
+                echo "   Latest:  $LATEST_VERSION"
+                if [ -n "$RELEASE_NOTES" ]; then
+                    echo "   Release Notes: $RELEASE_NOTES"
+                fi
+                echo "   To upgrade, run:"
+                echo -e "   \033[1mcurl -fsSL https://raw.githubusercontent.com/hopskipnfall/EmuLinker-K/master/release/setup.sh | bash\033[0m\n"
+                echo "   Starting server with current version in 5 seconds..."
+                sleep 5
+            else
+                echo "✅ Server is up to date ($LOCAL_VERSION)."
             fi
-            echo "   To upgrade, run:"
-            echo -e "   \033[1mcurl -fsSL https://raw.githubusercontent.com/hopskipnfall/EmuLinker-K/master/release/setup.sh | bash\033[0m\n"
-            echo "   Starting server with current version in 5 seconds..."
-            sleep 5
         else
-            echo "✅ Server is up to date ($LOCAL_VERSION)."
+             echo "⚠️  Could not determine versions. Skipping check."
         fi
     else
-         echo "⚠️  Could not determine versions. Skipping check."
+        echo "⚠️  Could not fetch update info. Skipping check."
     fi
 else
-    echo "⚠️  Could not fetch update info. Skipping check."
+    echo "ℹ️  Using custom jar. Skipping update check."
 fi
 
 print_startup_logs() {


### PR DESCRIPTION
## Overview
This PR introduces a survey feature to query active players about lag, and implements scripting/tooling enhancements to enable safe remote server deployment.

## Features & Changes

### 1. Lag Survey & Telemetry System
- **Dynamic Survey Triggers**: Prompts users with lag-related survey questions under specific global triggers and start button detection.
- **Rolling Telemetry Window**: Automatically tracks individual user activity and auto-prunes telemetry logs outside a rolling 5-minute window.
- **ROM Whitelists**: Restricts survey prompts only to pre-approved ROM names.
- **Improved Stability & Testing**: Added comprehensive E2E and unit test coverage for `KailleraGame`, `KailleraUser`, and `SurveyManager`.

### 2. Scripting & Safe Deployment Upgrades
- **Custom JAR Flag**: Updated `release/start-server.sh` with a `--jar <path>` override option to start the server with custom jar paths. Skipping update check logic is automatically triggered when overriding the JAR to avoid startup version check delays.
- **Safe Deploy Agent Skills**: Added local Antigravity skills under `.agents/skills/`:
  - `emulinkerk-server-status`: Analyzes remote server log files backwards from the last hourly baseline update to count active players and running games.
  - `emulinkerk-deploy-nue`: Orchestrates clean Gradle builds, uploads development builds, verifies server state using `emulinkerk-server-status`, and cleanly restarts the remote server if it's empty (or upon user confirmation).