### PR TITLE
Implement Survey Ingestion & AWS Backend Integration

### DIFF
--- a/emulinker/build.gradle.kts
+++ b/emulinker/build.gradle.kts
@@ -60,6 +60,10 @@ dependencies {
   implementation("io.ktor:ktor-server-netty-jvm:$ktorVersion")
   implementation("io.ktor:ktor-server-status-pages-jvm:$ktorVersion")
   implementation("io.ktor:ktor-server-default-headers-jvm:$ktorVersion")
+  implementation("io.ktor:ktor-client-core-jvm:$ktorVersion")
+  implementation("io.ktor:ktor-client-cio-jvm:$ktorVersion")
+  implementation("io.ktor:ktor-client-content-negotiation-jvm:$ktorVersion")
+  implementation("io.ktor:ktor-serialization-kotlinx-json-jvm:$ktorVersion")
 
   implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.7.1")
 

--- a/emulinker/conf/emulinker.cfg
+++ b/emulinker/conf/emulinker.cfg
@@ -76,3 +76,10 @@ metrics.enabled=true
 metrics.loggingFrequencySeconds=120
 
 server.maxPing=200
+
+# SURVEY BACKEND CONFIGURATION
+# ============================
+# The endpoint URL of the AWS survey backend function.
+# survey.apiEndpoint=ENDPOINT_URL_HERE
+# The secret API key used to authenticate EmuLinker with the AWS survey backend.
+# survey.apiKey=YOUR_SECRET_API_KEY

--- a/emulinker/src/main/java/org/emulinker/config/RuntimeFlags.kt
+++ b/emulinker/src/main/java/org/emulinker/config/RuntimeFlags.kt
@@ -51,6 +51,8 @@ data class RuntimeFlags(
   val v086BufferSize: Int,
   val surveyEnabled: Boolean,
   val surveyGameWhitelist: List<String>,
+  val surveyApiEndpoint: String,
+  val surveyApiKey: String,
 ) {
 
   init {

--- a/emulinker/src/main/java/org/emulinker/kaillera/model/SurveyManager.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/model/SurveyManager.kt
@@ -1,10 +1,22 @@
 package org.emulinker.kaillera.model
 
 import com.google.common.flogger.FluentLogger
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.put
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
 import io.netty.buffer.ByteBuf
+import java.util.concurrent.CompletableFuture
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.TimeMark
 import kotlin.time.TimeSource
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.Serializable
 import org.emulinker.config.RuntimeFlags
 import org.emulinker.proto.Event
 import org.emulinker.proto.EventKt.fanOut
@@ -19,12 +31,30 @@ import org.emulinker.util.EmuLang
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
+@Serializable
+data class SurveyMetadataRequest(
+  val username: String,
+  val ipAddress: String,
+  val romName: String,
+  val surveyResponse: String,
+  val serverName: String,
+  val emulatorName: String?,
+  val connectionType: String,
+  val frameDelay: Int,
+)
+
+@Serializable data class SurveyMetadataResponse(val surveyId: String, val uploadUrl: String)
+
 class SurveyManager(private val game: KailleraGame) : KoinComponent {
 
   private val flags: RuntimeFlags by inject()
+  private val httpClient: HttpClient by inject()
 
   val isSurveyEligibleForGame =
-    flags.surveyEnabled && flags.surveyGameWhitelist.any { Regex(it).containsMatchIn(game.romName) }
+    flags.surveyEnabled &&
+      flags.surveyApiEndpoint.isNotBlank() &&
+      flags.surveyApiKey.isNotBlank() &&
+      flags.surveyGameWhitelist.any { Regex(it).containsMatchIn(game.romName) }
 
   private var gameStartTimeMark: TimeMark? = null
   var lastSurveyAskedTimeMark: TimeMark? = null
@@ -150,7 +180,66 @@ class SurveyManager(private val game: KailleraGame) : KoinComponent {
         response,
         surveyLog?.size ?: 0,
       )
-    // TODO: Send response and surveyLog to a server for analysis.
+
+    val endpoint = flags.surveyApiEndpoint
+    val apiKey = flags.surveyApiKey
+
+    CompletableFuture.runAsync {
+      try {
+        runBlocking {
+          val ipAddress = user.socketAddress!!.address.hostAddress
+          val emulatorName = user.clientType
+          val connectionType = user.connectionType.readableName
+          val frameDelay = user.frameDelay
+
+          val requestBody =
+            SurveyMetadataRequest(
+              username = user.name!!,
+              ipAddress = ipAddress,
+              romName = game.romName,
+              surveyResponse = response,
+              serverName = flags.serverName,
+              emulatorName = emulatorName,
+              connectionType = connectionType,
+              frameDelay = frameDelay,
+            )
+
+          logger.atInfo().log("Registering survey response metadata with backend...")
+          val metadataResponse: SurveyMetadataResponse =
+            httpClient
+              .post("$endpoint/survey") {
+                contentType(ContentType.Application.Json)
+                header("X-API-Key", apiKey)
+                setBody(requestBody)
+              }
+              .body()
+
+          if (surveyLog != null && surveyLog.isNotEmpty()) {
+            logger.atInfo().log("Uploading binary survey log (size: ${surveyLog.size} bytes)...")
+            val putResponse: HttpResponse =
+              httpClient.put(metadataResponse.uploadUrl) {
+                contentType(ContentType.Application.OctetStream)
+                setBody(surveyLog)
+              }
+            if (putResponse.status.value !in 200..299) {
+              logger
+                .atWarning()
+                .log("Failed to upload binary survey log: S3 returned status ${putResponse.status}")
+            } else {
+              logger.atInfo().log("Successfully uploaded binary survey log to S3.")
+            }
+          }
+          logger
+            .atInfo()
+            .log("Successfully processed and reported survey response for user: ${user.name}")
+        }
+      } catch (e: Exception) {
+        logger
+          .atSevere()
+          .withCause(e)
+          .log("Failed to report survey response to backend for user: ${user.name}")
+      }
+    }
   }
 
   /**

--- a/emulinker/src/main/java/org/emulinker/kaillera/pico/KoinModule.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/pico/KoinModule.kt
@@ -4,6 +4,10 @@ import com.codahale.metrics.MetricRegistry
 import com.google.common.flogger.FluentLogger
 import io.github.redouane59.twitter.TwitterClient
 import io.github.redouane59.twitter.signature.TwitterCredentials
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.serialization.kotlinx.json.json
 import java.nio.charset.Charset
 import java.nio.charset.UnsupportedCharsetException
 import java.util.Timer
@@ -15,6 +19,7 @@ import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
+import kotlinx.serialization.json.Json
 import org.apache.commons.configuration.Configuration
 import org.emulinker.config.RuntimeFlags
 import org.emulinker.kaillera.access.AccessManager
@@ -180,6 +185,8 @@ val koinModule = module {
           v086BufferSize = config.getInt("controllers.v086.bufferSize", 4096),
           surveyEnabled = config.getBoolean("survey.enabled", false),
           surveyGameWhitelist = config.getStringArray("survey.gameWhitelist").toList(),
+          surveyApiEndpoint = config.getString("survey.apiEndpoint", ""),
+          surveyApiKey = config.getString("survey.apiKey", ""),
         )
 
       charsetDoNotUse = flags.charset
@@ -191,6 +198,19 @@ val koinModule = module {
         .withCause(e)
         .log("Failed to create RuntimeFlags.")
       throw e
+    }
+  }
+
+  single<HttpClient> {
+    HttpClient(CIO) {
+      install(ContentNegotiation) {
+        json(
+          Json {
+            ignoreUnknownKeys = true
+            prettyPrint = false
+          }
+        )
+      }
     }
   }
 

--- a/emulinker/src/test/java/org/emulinker/kaillera/access/AccessManager2Test.kt
+++ b/emulinker/src/test/java/org/emulinker/kaillera/access/AccessManager2Test.kt
@@ -352,6 +352,8 @@ class AccessManager2Test {
         v086BufferSize = 4096,
         surveyEnabled = false,
         surveyGameWhitelist = emptyList(),
+        surveyApiEndpoint = "",
+        surveyApiKey = "",
       )
   }
 }

--- a/emulinker/src/test/java/org/emulinker/kaillera/model/KailleraUserTest.kt
+++ b/emulinker/src/test/java/org/emulinker/kaillera/model/KailleraUserTest.kt
@@ -91,6 +91,8 @@ class KailleraUserTest {
       v086BufferSize = 4096,
       surveyEnabled = false,
       surveyGameWhitelist = emptyList(),
+      surveyApiEndpoint = "",
+      surveyApiKey = "",
     )
 
   private val mockClientHandler = mock<V086ClientHandler>()

--- a/emulinker/src/test/java/org/emulinker/kaillera/model/SurveyManagerTest.kt
+++ b/emulinker/src/test/java/org/emulinker/kaillera/model/SurveyManagerTest.kt
@@ -2,6 +2,8 @@ package org.emulinker.kaillera.model
 
 import com.google.common.truth.Truth.assertThat
 import io.netty.buffer.Unpooled
+import java.net.InetAddress
+import java.net.InetSocketAddress
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -25,6 +27,8 @@ class SurveyManagerTest {
     mock<RuntimeFlags> {
       on { surveyEnabled } doReturn true
       on { surveyGameWhitelist } doReturn listOf("smash", "tekken")
+      on { surveyApiEndpoint } doReturn "http://localhost"
+      on { surveyApiKey } doReturn "test-key"
     }
 
   // A user who has not yet given consent (surveyConsent == null, no timemark set).
@@ -34,8 +38,12 @@ class SurveyManagerTest {
     on { surveyConsentAskedTimeMark } doReturn null
   }
 
-  // A user who has positively consented to surveys.
   private val consentedUser: KailleraUser = mock {
+    on { name } doReturn "PlayerOne"
+    on { socketAddress } doReturn InetSocketAddress(InetAddress.getLoopbackAddress(), 27001)
+    on { clientType } doReturn "MAME 0.119"
+    on { connectionType } doReturn ConnectionType.EXCELLENT
+    on { frameDelay } doReturn 2
     on { frameCount } doReturn 3
     on { surveyConsent } doReturn true
     on { surveyConsentAskedTimeMark } doReturn TimeSource.Monotonic.markNow()
@@ -79,6 +87,8 @@ class SurveyManagerTest {
       mock<RuntimeFlags> {
         on { surveyEnabled } doReturn false
         on { surveyGameWhitelist } doReturn listOf("smash")
+        on { surveyApiEndpoint } doReturn "http://localhost"
+        on { surveyApiKey } doReturn "test-key"
       }
     stopKoin()
     startKoin { modules(module { single { disabledFlags } }) }


### PR DESCRIPTION
# Walkthrough: EmuLinker-K Survey Integration

We have successfully implemented the EmuLinker-K survey integration feature to asynchronously upload player responses and binary telemetry logs to the serverless AWS survey backend. This walkthrough has been updated to reflect the subsequent code review improvements.

---

## Changes Made

### 1. Build & Dependencies
- **[build.gradle.kts](file:///Users/ness/workspaces/EmuLinker-K/emulinker/build.gradle.kts)**: 
  - Added Ktor Client core, CIO engine, Content Negotiation, and Kotlinx Serialization Json libraries.

### 2. Configuration & Dependency Injection
- **[RuntimeFlags.kt](file:///Users/ness/workspaces/EmuLinker-K/emulinker/src/main/java/org/emulinker/config/RuntimeFlags.kt)**:
  - Added `surveyApiEndpoint: String` and `surveyApiKey: String` configuration parameters.
- **[KoinModule.kt](file:///Users/ness/workspaces/EmuLinker-K/emulinker/src/main/java/org/emulinker/kaillera/pico/KoinModule.kt)**:
  - Parsed `survey.apiEndpoint` and `survey.apiKey` from configuration.
  - Initialized `surveyApiEndpoint` fallback to an empty string `""` (avoiding git repository exposure of production backend endpoint URLs).
  - Declared a Koin singleton `HttpClient(CIO)` with JSON Content Negotiation enabled.
- **[emulinker.cfg](file:///Users/ness/workspaces/EmuLinker-K/emulinker/conf/emulinker.cfg)**:
  - Added documented templates for `survey.apiEndpoint` (defaulting to a generic `ENDPOINT_URL_HERE` placeholder) and `survey.apiKey` parameters.

### 3. Outbound Upload Service
- **[SurveyManager.kt](file:///Users/ness/workspaces/EmuLinker-K/emulinker/src/main/java/org/emulinker/kaillera/model/SurveyManager.kt)**:
  - Injected `HttpClient`.
  - Created serializable data classes `SurveyMetadataRequest` and `SurveyMetadataResponse` representing the API contracts.
  - Refined payload structure per code review feedback:
    - Removed `surveyTime` (timestamp is inferred on backend request ingestion).
    - Removed `logSize` (inferred from S3 log metadata).
    - Removed `serverIp` (inferred from source IP of Lambda request).
    - Removed `kailleraClientName` entirely from the API request as it was redundant.
    - Added `connectionType` (sending the readable string name, e.g. `"Excellent"`, `"LAN"`, `"DISABLED"`) to the outbound payload.
    - Updated `username` to assert non-null name (`user.name!!`) and `ipAddress` to assert non-null socket address (`user.socketAddress!!.address.hostAddress`).
  - Implemented asynchronous, non-blocking upload flow inside `reportSurveyResponse`:
    - First makes an HTTP POST to `<apiEndpoint>/survey` to register response metadata.
    - Resolves the S3 pre-signed `uploadUrl`.
    - Uploads the raw gameplay telemetry byte array (if present) via an HTTP PUT directly to S3.
    - All network operations execute inside `CompletableFuture.runAsync` to guarantee game event loops remain free of lag.

### 4. Tests
- **[KailleraUserTest.kt](file:///Users/ness/workspaces/EmuLinker-K/emulinker/src/test/java/org/emulinker/kaillera/model/KailleraUserTest.kt)** & **[AccessManager2Test.kt](file:///Users/ness/workspaces/EmuLinker-K/emulinker/src/test/java/org/emulinker/kaillera/access/AccessManager2Test.kt)**:
  - Updated mock `RuntimeFlags` constructors with placeholder strings to keep mock setups consistent.
- **[SurveyManagerTest.kt](file:///Users/ness/workspaces/EmuLinker-K/emulinker/src/test/java/org/emulinker/kaillera/model/SurveyManagerTest.kt)**:
  - Imported `java.net.InetAddress` and `java.net.InetSocketAddress` instead of using inline fully qualified class names.
  - Updated the mock stubs in the unit tests to mock all requested fields (`name`, `socketAddress`, `clientType`, `connectionType`, `frameDelay`) to prevent null assertions from throwing NPEs in asynchronous contexts.
  - Stubbed `surveyApiEndpoint` and `surveyApiKey` properties on `mockFlags` and `disabledFlags` to return valid local test string configurations.

---

## Verification & Testing Results

### Automated Tests
- Ran the unit test suite and verified that all 333 test cases compile and pass:
  ```bash
  ./gradlew :emulinker:test
  ```
- Executed spotless checks to format all modified source files:
  ```bash
  ./gradlew spotlessApply
  ```
- Verified that the full project builds successfully:
  ```bash
  ./gradlew build
  ```
