### PR TITLE
feat: N64 controller input parser

### DIFF
--- a/docs/n64_controller_encoding.md
+++ b/docs/n64_controller_encoding.md
@@ -1,0 +1,107 @@
+# N64 Controller Input Encoding in Kaillera
+
+This document outlines how Nintendo 64 (N64) controller inputs are encoded within Kaillera game data packets. It explains the packet layouts, header formats, and bitwise button/joystick structures for both standard and RAW data modes.
+
+---
+
+## 1. Overview of Packet Structure
+
+A Kaillera game data packet consists of a **Header** followed by one or more **Controller Input Frames**. The format of the header determines whether the controller data is in Standard Mode or RAW Mode.
+
+```
++------------------+-----------------------------+
+|  Header Bytes    |  Controller Input Frame(s)  |
+|  (Standard/RAW)  |  (Buttons & Joystick data)  |
++------------------+-----------------------------+
+```
+
+* **Byte 0 (Player Select):** Indicates player designation (typically `0x10`, `0x11`, etc.).
+* **Byte 1 (Format Byte):** Identifies the format mode:
+  * `0x20` indicates **Standard Mode**
+  * `0x21` indicates **RAW Mode**
+
+---
+
+## 2. Encoding Formats
+
+### A. Standard Mode (`0x20`)
+
+In Standard Mode, the client uses a fixed 12-byte header. The first frame of controller input begins immediately at index 12 of the packet.
+
+* **Header Size:** 12 bytes
+* **First Frame Offset:** 12
+* **Frame Size:** 4 bytes
+
+```
+Byte Offset:
+ 0      1                                  12
++------+------+---------------------------+-------------+
+| PlayerSelect | 0x20 (Format) | ... (10 bytes padding) ... | Frame 1 ... |
++------+------+---------------------------+-------------+
+```
+
+### B. RAW Mode (`0x21`)
+
+In RAW Mode (common in games communicating raw/unfiltered emulator packets like Smash 64), the client uses a shorter 7-byte header. The first frame of controller input begins immediately at index 7.
+
+* **Header Size:** 7 bytes
+* **First Frame Offset:** 7
+* **Frame Size:** Variable (defined by the player's connection latency setting, e.g., 8 bytes or 24 bytes). However, the first frame is always positioned at index 7.
+
+```
+Byte Offset:
+ 0      1                          7
++------+------+-------------------+-------------+
+| PlayerSelect | 0x21 (Format) | ... (5 bytes padding) ... | Frame 1 ... |
++------+------+-------------------+-------------+
+```
+
+---
+
+## 3. Controller Input Frame Layout
+
+Each controller input frame has a standard 4-byte layout that maps all N64 buttons and the analog joystick coordinates:
+
+```
++-----------------------------------+
+| Byte 0: Buttons High Byte         |
+| Byte 1: Buttons Low Byte          |
+| Byte 2: Joystick X Axis (Signed)  |
+| Byte 3: Joystick Y Axis (Signed)  |
++-----------------------------------+
+```
+
+### A. Buttons High Byte (Byte 0)
+
+| Bit | Hex Value | Button |
+|:---:|:---------:|:------:|
+| 7   | `0x80`    | A      |
+| 6   | `0x40`    | B      |
+| 5   | `0x20`    | Z      |
+| 4   | `0x10`    | Start  |
+| 3   | `0x08`    | D-Up   |
+| 2   | `0x04`    | D-Down |
+| 1   | `0x02`    | D-Left |
+| 0   | `0x01`    | D-Right|
+
+### B. Buttons Low Byte (Byte 1)
+
+| Bit | Hex Value | Button |
+|:---:|:---------:|:------:|
+| 7   | `0x80`    | (Unused/Reserved) |
+| 6   | `0x40`    | (Unused/Reserved) |
+| 5   | `0x20`    | L      |
+| 4   | `0x10`    | R      |
+| 3   | `0x08`    | C-Up   |
+| 2   | `0x04`    | C-Down |
+| 1   | `0x02`    | C-Left |
+| 0   | `0x01`    | C-Right|
+
+### C. Joystick Coordinates (Bytes 2 & 3)
+
+The analog joystick positions are mapped to Bytes 2 and 3 as signed 8-bit integers:
+
+* **Byte 2 (Joystick X):** Represents the horizontal position.
+  * Range: `-128` (Fully Left) to `127` (Fully Right). Neutral position is `0`.
+* **Byte 3 (Joystick Y):** Represents the vertical position.
+  * Range: `-128` (Fully Down) to `127` (Fully Up). Neutral position is `0`.

--- a/emulinker/src/main/java/org/emulinker/kaillera/controller/input/N64ControllerInput.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/controller/input/N64ControllerInput.kt
@@ -1,0 +1,108 @@
+package org.emulinker.kaillera.controller.input
+
+import io.netty.buffer.ByteBuf
+
+/** Represents a parsed single frame of N64 controller input. */
+class N64ControllerFrame(
+  val buttonsHigh: Int,
+  val buttonsLow: Int,
+  val joystickX: Byte,
+  val joystickY: Byte,
+) {
+  // High Byte buttons
+  val a: Boolean
+    get() = (buttonsHigh and 0x80) != 0
+
+  val b: Boolean
+    get() = (buttonsHigh and 0x40) != 0
+
+  val z: Boolean
+    get() = (buttonsHigh and 0x20) != 0
+
+  val start: Boolean
+    get() = (buttonsHigh and 0x10) != 0
+
+  val dpadUp: Boolean
+    get() = (buttonsHigh and 0x08) != 0
+
+  val dpadDown: Boolean
+    get() = (buttonsHigh and 0x04) != 0
+
+  val dpadLeft: Boolean
+    get() = (buttonsHigh and 0x02) != 0
+
+  val dpadRight: Boolean
+    get() = (buttonsHigh and 0x01) != 0
+
+  // Low Byte buttons
+  val l: Boolean
+    get() = (buttonsLow and 0x20) != 0
+
+  val r: Boolean
+    get() = (buttonsLow and 0x10) != 0
+
+  val cUp: Boolean
+    get() = (buttonsLow and 0x08) != 0
+
+  val cDown: Boolean
+    get() = (buttonsLow and 0x04) != 0
+
+  val cLeft: Boolean
+    get() = (buttonsLow and 0x02) != 0
+
+  val cRight: Boolean
+    get() = (buttonsLow and 0x01) != 0
+
+  override fun toString(): String {
+    val buttons = buildList {
+      if (start) add("Start")
+      if (a) add("A")
+      if (b) add("B")
+      if (z) add("Z")
+      if (l) add("L")
+      if (r) add("R")
+      if (dpadUp) add("D-Up")
+      if (dpadDown) add("D-Down")
+      if (dpadLeft) add("D-Left")
+      if (dpadRight) add("D-Right")
+      if (cUp) add("C-Up")
+      if (cDown) add("C-Down")
+      if (cLeft) add("C-Left")
+      if (cRight) add("C-Right")
+    }
+    val buttonsStr = if (buttons.isNotEmpty()) buttons.joinToString("+") else "None"
+    return "N64Frame{Buttons:$buttonsStr, Joy:($joystickX, $joystickY)}"
+  }
+}
+
+/**
+ * Parses Kaillera game data network packets into N64 controller inputs.
+ *
+ * Supports both standard mode (0x20 format, 12-byte header) and RAW mode (0x21 format, 7-byte
+ * header).
+ */
+class N64ControllerInputParser {
+  /**
+   * Parses the N64 controller input frame from a Kaillera game data network packet. Returns null if
+   * the packet is invalid or too short.
+   */
+  fun parse(data: ByteBuf): N64ControllerFrame? {
+    if (data.readableBytes() < 2) return null
+
+    val formatByte = data.getByte(data.readerIndex() + 1).toInt() and 0xFF
+    val isRaw = (formatByte == 0x21)
+    val headerSize = if (isRaw) 7 else 12
+
+    if (data.readableBytes() < headerSize + 4) return null
+
+    val offset = data.readerIndex() + headerSize
+    if (offset + 3 < data.writerIndex()) {
+      val buttonsHigh = data.getByte(offset).toInt() and 0xFF
+      val buttonsLow = data.getByte(offset + 1).toInt() and 0xFF
+      val joystickX = data.getByte(offset + 2)
+      val joystickY = data.getByte(offset + 3)
+      return N64ControllerFrame(buttonsHigh, buttonsLow, joystickX, joystickY)
+    }
+    return null
+  }
+}

--- a/emulinker/src/main/java/org/emulinker/kaillera/model/SurveyManager.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/model/SurveyManager.kt
@@ -18,6 +18,7 @@ import kotlin.time.TimeSource
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.Serializable
 import org.emulinker.config.RuntimeFlags
+import org.emulinker.kaillera.controller.input.N64ControllerInputParser
 import org.emulinker.proto.Event
 import org.emulinker.proto.EventKt.fanOut
 import org.emulinker.proto.EventKt.receivedGameData
@@ -38,7 +39,7 @@ data class SurveyMetadataRequest(
   val romName: String,
   val surveyResponse: String,
   val serverName: String,
-  val emulatorName: String?,
+  val emulatorName: String,
   val connectionType: String,
   val frameDelay: Int,
 )
@@ -48,6 +49,7 @@ data class SurveyMetadataRequest(
 class SurveyManager(private val game: KailleraGame) : KoinComponent {
 
   private val flags: RuntimeFlags by inject()
+  private val inputParser: N64ControllerInputParser by inject()
   private val httpClient: HttpClient? by lazy { getKoin().getOrNull<HttpClient>() }
 
   val isSurveyEligibleForGame =
@@ -93,7 +95,7 @@ class SurveyManager(private val game: KailleraGame) : KoinComponent {
     val eligiblePlayers = game.players.filter { it.surveyConsent == true }
 
     if (eligiblePlayers.isNotEmpty()) {
-      if (checkStartPressed(data, bytesPerAction)) {
+      if (checkStartPressed(data)) {
         pendingSurveyGameLog =
           GameLog.newBuilder().addAllEvents(telemetryEvents).build().toByteArray()
         for (player in eligiblePlayers) {
@@ -128,10 +130,7 @@ class SurveyManager(private val game: KailleraGame) : KoinComponent {
     )
   }
 
-  private fun checkStartPressed(data: ByteBuf, bytesPerAction: Int): Boolean {
-    if (data.readableBytes() < 13) return false
-    return (data.getByte(data.readerIndex() + 12).toInt() and 0b00010000) != 0
-  }
+  private fun checkStartPressed(data: ByteBuf): Boolean = inputParser.parse(data)?.start == true
 
   fun handleChat(user: KailleraUser, message: String): Boolean {
     if (!isSurveyEligibleForGame) return false
@@ -198,21 +197,16 @@ class SurveyManager(private val game: KailleraGame) : KoinComponent {
     CompletableFuture.runAsync {
       try {
         runBlocking {
-          val ipAddress = user.socketAddress!!.address.hostAddress
-          val emulatorName = user.clientType
-          val connectionType = user.connectionType.readableName
-          val frameDelay = user.frameDelay
-
           val requestBody =
             SurveyMetadataRequest(
               username = user.name!!,
-              ipAddress = ipAddress,
+              ipAddress = user.socketAddress?.address?.hostAddress!!,
               romName = game.romName,
               surveyResponse = response,
-              serverName = flags.serverName,
-              emulatorName = emulatorName,
-              connectionType = connectionType,
-              frameDelay = frameDelay,
+              serverName = flags.serverName.takeIf { it.isNotBlank() } ?: "(unset)",
+              emulatorName = user.clientType!!,
+              connectionType = user.connectionType.readableName,
+              frameDelay = user.frameDelay,
             )
 
           logger.atInfo().log("Registering survey response metadata with backend...")

--- a/emulinker/src/main/java/org/emulinker/kaillera/pico/KoinModule.kt
+++ b/emulinker/src/main/java/org/emulinker/kaillera/pico/KoinModule.kt
@@ -26,6 +26,7 @@ import org.emulinker.kaillera.access.AccessManager
 import org.emulinker.kaillera.access.AccessManager2
 import org.emulinker.kaillera.controller.CombinedKailleraController
 import org.emulinker.kaillera.controller.KailleraServerController
+import org.emulinker.kaillera.controller.input.N64ControllerInputParser
 import org.emulinker.kaillera.controller.v086.V086Controller
 import org.emulinker.kaillera.lookingforgame.TwitterBroadcaster
 import org.emulinker.kaillera.master.MasterListStatsCollector
@@ -66,6 +67,7 @@ val koinModule = module {
   singleOf(::TwitterBroadcaster)
   singleOf(::ReleaseInfo)
   singleOf(::PublicServerInformation)
+  singleOf(::N64ControllerInputParser)
 
   factoryOf(::EmuLinkerMasterUpdateTask).bind<MasterListUpdateTask>()
   factoryOf(::CombinedKailleraController)

--- a/emulinker/src/test/java/org/emulinker/kaillera/controller/input/N64ControllerInputTest.kt
+++ b/emulinker/src/test/java/org/emulinker/kaillera/controller/input/N64ControllerInputTest.kt
@@ -1,0 +1,221 @@
+package org.emulinker.kaillera.controller.input
+
+import com.google.common.truth.Truth.assertThat
+import io.netty.buffer.Unpooled
+import kotlin.test.Test
+
+class N64ControllerInputTest {
+
+  private val parser = N64ControllerInputParser()
+
+  @Test
+  fun `parse standard mode packet with no inputs`() {
+    val data =
+      Unpooled.buffer(24).apply {
+        writeByte(0x10) // Player 1 select
+        writeByte(0x20) // Standard mode format
+        writeZero(10) // Pad header to 12 bytes
+        writeZero(12) // 3 frames of 4-byte actions (all zero)
+      }
+
+    val frame = parser.parse(data)
+    assertThat(frame).isNotNull()
+    assertThat(frame!!.a).isFalse()
+    assertThat(frame.start).isFalse()
+    assertThat(frame.joystickX).isEqualTo(0.toByte())
+    assertThat(frame.joystickY).isEqualTo(0.toByte())
+
+    data.release()
+  }
+
+  @Test
+  fun `parse standard mode packet with buttons and joystick`() {
+    val data =
+      Unpooled.buffer(24).apply {
+        writeByte(0x10)
+        writeByte(0x20)
+        writeZero(10)
+
+        // Frame 1: A and START pressed, Joystick X = 10, Y = -20
+        writeByte(0x90) // A (0x80) + START (0x10)
+        writeByte(0x00)
+        writeByte(10)
+        writeByte(-20)
+
+        writeZero(8) // Remaining frames
+      }
+
+    val frame = parser.parse(data)
+    assertThat(frame).isNotNull()
+    assertThat(frame!!.a).isTrue()
+    assertThat(frame.start).isTrue()
+    assertThat(frame.b).isFalse()
+    assertThat(frame.joystickX).isEqualTo(10.toByte())
+    assertThat(frame.joystickY).isEqualTo((-20).toByte())
+
+    data.release()
+  }
+
+  @Test
+  fun `parse RAW mode packet with 8-byte frame size`() {
+    val data =
+      Unpooled.buffer(24).apply {
+        writeByte(0x10)
+        writeByte(0x21) // RAW mode
+        writeZero(5) // Pad header to 7 bytes
+
+        // Frame 1: START pressed (index 7), Joystick X = 1, Y = -1
+        writeByte(0x10) // buttonsHigh
+        writeByte(0x00) // buttonsLow
+        writeByte(1)
+        writeByte(-1)
+        writeZero(4) // Pad frame to 8 bytes
+
+        writeZero(9) // Remaining bytes
+      }
+
+    val frame = parser.parse(data)
+    assertThat(frame).isNotNull()
+    assertThat(frame!!.start).isTrue()
+    assertThat(frame.joystickX).isEqualTo(1.toByte())
+    assertThat(frame.joystickY).isEqualTo((-1).toByte())
+
+    data.release()
+  }
+
+  @Test
+  fun `parse RAW mode packet with 24-byte frame size`() {
+    val data =
+      Unpooled.buffer(24).apply {
+        writeByte(0x10)
+        writeByte(0x21) // RAW mode
+        writeZero(5) // Pad header to 7 bytes
+
+        // Frame 1: START pressed (index 7), Joystick X = 5, Y = 5
+        writeByte(0x10)
+        writeByte(0x00)
+        writeByte(5)
+        writeByte(5)
+        writeZero(12)
+      }
+
+    val frame = parser.parse(data)
+    assertThat(frame).isNotNull()
+    assertThat(frame!!.start).isTrue()
+    assertThat(frame.joystickX).isEqualTo(5.toByte())
+
+    data.release()
+  }
+
+  @Test
+  fun `parse invalid short packets`() {
+    val data1 = Unpooled.buffer(1).apply { writeByte(0x10) }
+    val frame1 = parser.parse(data1)
+    assertThat(frame1).isNull()
+    data1.release()
+
+    val data2 =
+      Unpooled.buffer(5).apply {
+        writeByte(0x10)
+        writeByte(0x20)
+        writeZero(3)
+      }
+    val frame2 = parser.parse(data2)
+    assertThat(frame2).isNull()
+    data2.release()
+  }
+
+  @Test
+  fun `toString formats frame state correctly`() {
+    val frame =
+      N64ControllerFrame(
+        buttonsHigh = 0x90, // A (0x80) + START (0x10)
+        buttonsLow = 0x18, // R (0x10) + C-Up (0x08)
+        joystickX = 15,
+        joystickY = -30,
+      )
+    assertThat(frame.toString()).isEqualTo("N64Frame{Buttons:Start+A+R+C-Up, Joy:(15, -30)}")
+  }
+
+  @Test
+  fun `parse individual high-byte buttons`() {
+    val buttons =
+      mapOf(
+        0x80 to N64ControllerFrame::a,
+        0x40 to N64ControllerFrame::b,
+        0x20 to N64ControllerFrame::z,
+        0x10 to N64ControllerFrame::start,
+        0x08 to N64ControllerFrame::dpadUp,
+        0x04 to N64ControllerFrame::dpadDown,
+        0x02 to N64ControllerFrame::dpadLeft,
+        0x01 to N64ControllerFrame::dpadRight,
+      )
+
+    buttons.forEach { (mask, property) ->
+      val frame =
+        N64ControllerFrame(buttonsHigh = mask, buttonsLow = 0, joystickX = 0, joystickY = 0)
+      assertThat(property.get(frame)).isTrue()
+
+      // Verify other buttons are false
+      buttons
+        .filterKeys { it != mask }
+        .values
+        .forEach { otherProp ->
+          assertThat(otherProp.get(frame)).isFalse()
+        }
+    }
+  }
+
+  @Test
+  fun `parse individual low-byte buttons`() {
+    val buttons =
+      mapOf(
+        0x20 to N64ControllerFrame::l,
+        0x10 to N64ControllerFrame::r,
+        0x08 to N64ControllerFrame::cUp,
+        0x04 to N64ControllerFrame::cDown,
+        0x02 to N64ControllerFrame::cLeft,
+        0x01 to N64ControllerFrame::cRight,
+      )
+
+    buttons.forEach { (mask, property) ->
+      val frame =
+        N64ControllerFrame(buttonsHigh = 0, buttonsLow = mask, joystickX = 0, joystickY = 0)
+      assertThat(property.get(frame)).isTrue()
+
+      // Verify other buttons are false
+      buttons
+        .filterKeys { it != mask }
+        .values
+        .forEach { otherProp ->
+          assertThat(otherProp.get(frame)).isFalse()
+        }
+    }
+  }
+
+  @Test
+  fun `joystick boundary values`() {
+    val frameMin = N64ControllerFrame(0, 0, -128, -128)
+    assertThat(frameMin.joystickX).isEqualTo((-128).toByte())
+    assertThat(frameMin.joystickY).isEqualTo((-128).toByte())
+
+    val frameMax = N64ControllerFrame(0, 0, 127, 127)
+    assertThat(frameMax.joystickX).isEqualTo(127.toByte())
+    assertThat(frameMax.joystickY).isEqualTo(127.toByte())
+  }
+
+  @Test
+  fun `parse packets with partial frame data`() {
+    for (extraBytes in 0..3) {
+      val data =
+        Unpooled.buffer(12 + extraBytes).apply {
+          writeByte(0x10)
+          writeByte(0x20)
+          writeZero(10 + extraBytes)
+        }
+      val frame = parser.parse(data)
+      assertThat(frame).isNull()
+      data.release()
+    }
+  }
+}

--- a/emulinker/src/test/java/org/emulinker/kaillera/model/SurveyManagerTest.kt
+++ b/emulinker/src/test/java/org/emulinker/kaillera/model/SurveyManagerTest.kt
@@ -11,6 +11,7 @@ import kotlin.time.Duration.Companion.minutes
 import kotlin.time.TimeMark
 import kotlin.time.TimeSource
 import org.emulinker.config.RuntimeFlags
+import org.emulinker.kaillera.controller.input.N64ControllerInputParser
 import org.emulinker.proto.GameLog
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
@@ -58,7 +59,14 @@ class SurveyManagerTest {
 
   @BeforeTest
   fun setUp() {
-    startKoin { modules(module { single { mockFlags } }) }
+    startKoin {
+      modules(
+        module {
+          single { mockFlags }
+          single { N64ControllerInputParser() }
+        }
+      )
+    }
   }
 
   @AfterTest
@@ -254,20 +262,109 @@ class SurveyManagerTest {
 
     val manager = SurveyManager(playingGame)
 
-    // Use reflection to set gameStartTimeMark to 9 minutes ago
+    // Use reflection to set gameStartTimeMark to 2 minutes ago
     val field = SurveyManager::class.java.getDeclaredField("gameStartTimeMark")
     field.isAccessible = true
     field.set(manager, TimeSource.Monotonic.markNow() - 9.minutes)
 
-    // N64 controller data layout with start bit set at byte 12 (0x10)
+    // N64 controller data layout with format byte 0x20, and start bit set at byte 12 (0x10)
     val data =
       Unpooled.buffer(24).apply {
-        writeZero(12)
-        writeByte(0x10) // start button pressed
-        writeZero(11)
+        writeByte(0x10) // Player 1 select
+        writeByte(0x20) // Standard mode format byte
+        writeZero(10) // Pad to 12 bytes
+        writeByte(0x10) // start button pressed (index 12)
+        writeZero(11) // Pad remaining
       }
 
     manager.onControllerInput(user, data, 2)
+
+    verify(playingGame).announce(any(), org.mockito.kotlin.eq(user))
+    data.release()
+  }
+
+  @Test
+  fun `onControllerInput checks start button and triggers survey in 8-byte mode`() {
+    val user: KailleraUser = mock {
+      on { frameCount } doReturn 6
+      on { surveyConsent } doReturn true
+    }
+    val playingGame =
+      mock<KailleraGame> {
+        on { romName } doReturn "smash"
+        on { status } doReturn GameStatus.PLAYING
+        on { players } doReturn mutableListOf(user)
+      }
+
+    val manager = SurveyManager(playingGame)
+
+    val field = SurveyManager::class.java.getDeclaredField("gameStartTimeMark")
+    field.isAccessible = true
+    field.set(manager, TimeSource.Monotonic.markNow() - 9.minutes)
+
+    // 8-byte mode controller data layout with start bit set at byte 7 (0x10)
+    // Hex: 102100000104011000000000000000000000000000000000
+    val data =
+      Unpooled.buffer(24).apply {
+        writeBytes(
+          byteArrayOf(
+            0x10.toByte(),
+            0x21.toByte(),
+            0x00.toByte(),
+            0x00.toByte(),
+            0x01.toByte(),
+            0x04.toByte(),
+            0x01.toByte(),
+            0x10.toByte(),
+          )
+        )
+        writeZero(16)
+      }
+
+    manager.onControllerInput(user, data, 8) // bytesPerAction = 8
+
+    verify(playingGame).announce(any(), org.mockito.kotlin.eq(user))
+    data.release()
+  }
+
+  @Test
+  fun `onControllerInput checks start button and triggers survey in 24-byte RAW mode`() {
+    val user: KailleraUser = mock {
+      on { frameCount } doReturn 6
+      on { surveyConsent } doReturn true
+    }
+    val playingGame =
+      mock<KailleraGame> {
+        on { romName } doReturn "smash"
+        on { status } doReturn GameStatus.PLAYING
+        on { players } doReturn mutableListOf(user)
+      }
+
+    val manager = SurveyManager(playingGame)
+
+    val field = SurveyManager::class.java.getDeclaredField("gameStartTimeMark")
+    field.isAccessible = true
+    field.set(manager, TimeSource.Monotonic.markNow() - 9.minutes)
+
+    // 24-byte RAW mode from real logs: start is bit 4 of byte 7 (0x10)
+    val data =
+      Unpooled.buffer(24).apply {
+        writeBytes(
+          byteArrayOf(
+            0x10.toByte(),
+            0x21.toByte(),
+            0x00.toByte(),
+            0x00.toByte(),
+            0x01.toByte(),
+            0x04.toByte(),
+            0x01.toByte(),
+            0x10.toByte(),
+          )
+        )
+        writeZero(16)
+      }
+
+    manager.onControllerInput(user, data, 24) // bytesPerAction = 24
 
     verify(playingGame).announce(any(), org.mockito.kotlin.eq(user))
     data.release()
@@ -288,17 +385,19 @@ class SurveyManagerTest {
 
     val manager = SurveyManager(playingGame)
 
-    // Use reflection to set gameStartTimeMark to 9 minutes ago
+    // Use reflection to set gameStartTimeMark to 2 minutes ago
     val field = SurveyManager::class.java.getDeclaredField("gameStartTimeMark")
     field.isAccessible = true
     field.set(manager, TimeSource.Monotonic.markNow() - 9.minutes)
 
-    // N64 controller data layout with start bit set at byte 12 (0x10)
+    // N64 controller data layout with format byte 0x20, and start bit set at byte 12 (0x10)
     val data =
       Unpooled.buffer(24).apply {
-        writeZero(12)
-        writeByte(0x10) // start button pressed
-        writeZero(11)
+        writeByte(0x10) // Player 1 select
+        writeByte(0x20) // Standard mode format byte
+        writeZero(10) // Pad to 12 bytes
+        writeByte(0x10) // start button pressed (index 12)
+        writeZero(11) // Pad remaining
       }
 
     manager.onControllerInput(user, data, 2)
@@ -311,53 +410,46 @@ class SurveyManagerTest {
   // ── Telemetry & Pruning ──────────────────────────────────────────────────────
 
   @Test
-  fun `telemetry is not recorded before 3 minutes from game start`() {
+  fun `telemetry is not recorded when survey is not eligible`() {
     val user = consentedUser
-    val playingGame =
+    val ineligibleGame =
       mock<KailleraGame> {
-        on { romName } doReturn "smash"
+        on { romName } doReturn "mario kart"
         on { status } doReturn GameStatus.PLAYING
         on { players } doReturn mutableListOf(user)
       }
-    val manager = SurveyManager(playingGame)
+    val manager = SurveyManager(ineligibleGame)
     manager.onGameStarted()
 
-    // Game started 2 minutes ago
-    val field = SurveyManager::class.java.getDeclaredField("gameStartTimeMark")
-    field.isAccessible = true
-    field.set(manager, TimeSource.Monotonic.markNow() - 2.minutes)
-
-    // Call updateDrift to run state machine.
     manager.updateDrift(System.nanoTime(), null)
-
-    // Call logReceivedGameData. It should be ignored because telemetry is not recording.
     manager.logReceivedGameData(1, System.nanoTime())
 
-    // Set gameStartTimeMark to 9 minutes ago so onControllerInput passes the delay check
+    // Set gameStartTimeMark to 2 minutes ago
+    val field = SurveyManager::class.java.getDeclaredField("gameStartTimeMark")
+    field.isAccessible = true
     field.set(manager, TimeSource.Monotonic.markNow() - 9.minutes)
 
     val data =
       Unpooled.buffer(24).apply {
-        writeZero(12)
+        writeByte(0x10) // Player 1 select
+        writeByte(0x20) // Standard mode format byte
+        writeZero(10) // Pad to 12 bytes
         writeByte(0x10) // start button pressed
         writeZero(11)
       }
 
     manager.onControllerInput(user, data, 2)
 
-    // Retrieve pendingSurveyGameLog
     val pendingLogField = SurveyManager::class.java.getDeclaredField("pendingSurveyGameLog")
     pendingLogField.isAccessible = true
     val bytes = pendingLogField.get(manager) as ByteArray?
 
-    assertThat(bytes).isNotNull()
-    val gameLog = GameLog.parseFrom(bytes!!)
-    assertThat(gameLog.eventsCount).isEqualTo(0)
+    assertThat(bytes).isNull()
     data.release()
   }
 
   @Test
-  fun `telemetry is recorded between 3 and 8 minutes from game start`() {
+  fun `telemetry is recorded when game start delay is satisfied`() {
     val user = consentedUser
     val playingGame =
       mock<KailleraGame> {
@@ -368,7 +460,7 @@ class SurveyManagerTest {
     val manager = SurveyManager(playingGame)
     manager.onGameStarted()
 
-    // Game started 4 minutes ago (satisfies needsToRecordForFirstSurvey: 4 >= 3)
+    // Game started 30 seconds ago (satisfies needsToRecordForFirstSurvey: 30s >= 0s)
     val field = SurveyManager::class.java.getDeclaredField("gameStartTimeMark")
     field.isAccessible = true
     field.set(manager, TimeSource.Monotonic.markNow() - 4.minutes)
@@ -378,12 +470,14 @@ class SurveyManagerTest {
     // Call logReceivedGameData. It should be recorded.
     manager.logReceivedGameData(1, System.nanoTime()) // Appends 1 receivedGameData event
 
-    // Set gameStartTimeMark to 9 minutes ago so onControllerInput passes the delay check
+    // Set gameStartTimeMark to 2 minutes ago so onControllerInput passes the delay check (2m > 1m)
     field.set(manager, TimeSource.Monotonic.markNow() - 9.minutes)
 
     val data =
       Unpooled.buffer(24).apply {
-        writeZero(12)
+        writeByte(0x10) // Player 1 select
+        writeByte(0x20) // Standard mode format byte
+        writeZero(10) // Pad to 12 bytes
         writeByte(0x10) // start button pressed
         writeZero(11)
       }
@@ -432,12 +526,14 @@ class SurveyManagerTest {
     // Event 2 is 4 mins old, so it should be kept.
     manager.updateDrift(6.minutes.inWholeNanoseconds, null)
 
-    // Set gameStartTimeMark to 10 minutes ago so onControllerInput passes the delay check
-    field.set(manager, TimeSource.Monotonic.markNow() - 10.minutes)
+    // Set gameStartTimeMark to 2 minutes ago so onControllerInput passes the delay check
+    field.set(manager, TimeSource.Monotonic.markNow() - 9.minutes)
 
     val data =
       Unpooled.buffer(24).apply {
-        writeZero(12)
+        writeByte(0x10) // Player 1 select
+        writeByte(0x20) // Standard mode format byte
+        writeZero(10) // Pad to 12 bytes
         writeByte(0x10) // start button pressed
         writeZero(11)
       }


### PR DESCRIPTION
Implements a stateless N64ControllerInputParser to parse Netty ByteBuf packets into N64ControllerFrame objects, optimizing memory, architecture, and SurveyManager trigger check logic.