### PR TITLE
i18n: Japanese translations for Survey subsystem

### DIFF
--- a/emulinker/src/main/i18n/messages_ja.properties
+++ b/emulinker/src/main/i18n/messages_ja.properties
@@ -190,3 +190,10 @@ Time.MinutesAbbreviation={0}分
 
 ! Notifies the user that the server will now start measuring lag at a new frame rate.
 Fps.NewFpsMeasurement={0,number,integer}fpsでラグ測定にしました
+
+# Survey
+Survey.Consent=学術研究調査へのご協力をお願いいたします。参加に同意いただける場合、プレイ体験に関する短い質問が定期的に送信されます。この研究の詳細については、こちらをご覧ください\: https://sites.gsu.edu/rjeter/lag\\n\\nアンケートに参加し、お住まいの国での成人（法的成人）であることを確認していただけますか？参加する場合は “yes” とお答えください。
+Survey.Question=過去 {0} 分間でのゲーム中のラグの状況を教えてください。\\n(1) なし\\n(2) 気になるが、プレイ可能\\n(3) プレイ不可能\\n回答に対応する番号で答えてください。
+Survey.ConsentYes=ご協力ありがとうございます\! 後ほど質問をお送りします。
+Survey.ConsentNo=了解しました。アンケートの質問は送信されません。
+Survey.Thanks=フィードバックありがとうございました\!


### PR DESCRIPTION
Adds Japanese translation mappings for the Survey consent prompt, lag questions, and feedback strings in messages_ja.properties.